### PR TITLE
Use `shell: bash` to fix `parameter cannot be found` error.

### DIFF
--- a/.github/workflows/release_windows_bin.yaml
+++ b/.github/workflows/release_windows_bin.yaml
@@ -1,10 +1,6 @@
 on:
-#  release:
-#    types: [published]
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ "*" ]
+  release:
+    types: [published]
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release_windows_bin.yaml
+++ b/.github/workflows/release_windows_bin.yaml
@@ -1,8 +1,10 @@
 on:
-  release:
-    types: [published]
-
-
+#  release:
+#    types: [published]
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ "*" ]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -34,6 +36,7 @@ jobs:
       run: cp -r src/oxotitan/.output/public/* src/ostorlab/ui/static
     - name: Delete titan files
       run: rm -rf src/oxotitan/*
+      shell: bash
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
- **Use `shell: bash` to fix `parameter cannot be found` error.**
