### PR TITLE
Enhance Agent Definition Validation: Type Field in Argument Object

### DIFF
--- a/src/ostorlab/agent/schema/agent_group_schema.json
+++ b/src/ostorlab/agent/schema/agent_group_schema.json
@@ -24,7 +24,13 @@
         "type": {
           "description": "[Required] - Type of the agent argument : respecting the jsonschema types.",
           "type": "string",
-          "maxLength": 2048
+            "enum": [
+                "string",
+                "number",
+                "boolean",
+                "array",
+                "object"
+            ]
         },
         "description": {
           "description": "[Optional] - Description of the agent argument.",

--- a/src/ostorlab/agent/schema/agent_schema.json
+++ b/src/ostorlab/agent/schema/agent_schema.json
@@ -166,7 +166,13 @@
           "type": {
             "description": "[Required] - Type of the agent argument : respecting the jsonschema types.",
             "type": "string",
-            "maxLength": 2048
+            "enum": [
+                "string",
+                "number",
+                "boolean",
+                "array",
+                "object"
+            ]
           },
           "description": {
             "description": "[Optional] - Description of the agent argument.",

--- a/src/ostorlab/cli/agent/build/build.py
+++ b/src/ostorlab/cli/agent/build/build.py
@@ -131,7 +131,7 @@ def build(
         )
         raise click.exceptions.Exit(2) from e
     except validator.ValidationError as e:
-        console.error("Definition file does not conform to the provided specification.")
+        console.error(f"Definition file does not conform to the provided specification: {e}")
         raise click.exceptions.Exit(2) from e
 
 

--- a/tests/agent/schema/invalid_agent.yaml
+++ b/tests/agent/schema/invalid_agent.yaml
@@ -1,0 +1,13 @@
+kind: Agent
+name: template_agent
+version: 0.0.1
+description: Agent description.
+in_selectors:
+  - v3.healthcheck.ping
+out_selectors: [ ]
+docker_file_path: Dockerfile
+docker_build_root: .
+args:
+  - name: test
+    type: test
+    description: test

--- a/tests/agent/schema/invalid_agent_group.yaml
+++ b/tests/agent/schema/invalid_agent_group.yaml
@@ -1,0 +1,11 @@
+kind: AgentGroup
+description: test.
+name: test
+agents:
+  - key: agent/ostorlab/tsunami
+  - key: agent/ostorlab/nmap
+  - key: agent/ostorlab/nuclei
+    args:
+      - name: test
+        type: test
+        description: test

--- a/tests/agent/schema/test_loader.py
+++ b/tests/agent/schema/test_loader.py
@@ -1,6 +1,7 @@
 """Tests for the validation of Json specifications for Agent & AgentGroup."""
 
 import io
+import pathlib
 
 import pytest
 
@@ -206,3 +207,31 @@ def testAgentGroupSpecValidation_whenRequiredParamDescriptionIsMissing_raiseVali
 
     with pytest.raises(validator.ValidationError):
         loader.load_agent_group_yaml(yaml_data_file)
+
+
+def testAgentSpecValidation_whenDefinitionHasInvalidArgType_raiseValidationError() -> (
+    None
+):
+    """Unit test to checks the validity of the Agent json-schema.
+    Case where the Agent definition is invalid : The type of argument is invalid.
+    """
+    invalid_agent_definition_path = pathlib.Path(__file__).parent / "invalid_agent.yaml"
+
+    with open(invalid_agent_definition_path, "r") as invalid_agent:
+        with pytest.raises(validator.ValidationError):
+            loader.load_agent_yaml(invalid_agent)
+
+
+def testAgentGroupSpecValidation_whenDefinitionHasInvalidArgType_raiseValidationError() -> (
+    None
+):
+    """Unit test to checks the validity of the AgentGroup json-schema.
+    Case where the AgentGroup definition is invalid : The type of argument is invalid.
+    """
+    invalid_agent_group_definition_path = (
+        pathlib.Path(__file__).parent / "invalid_agent_group.yaml"
+    )
+
+    with open(invalid_agent_group_definition_path, "r") as invalid_agent_group:
+        with pytest.raises(validator.ValidationError):
+            loader.load_agent_group_yaml(invalid_agent_group)

--- a/tests/cli/agent/build/assets/invalid_agent_def.yaml
+++ b/tests/cli/agent/build/assets/invalid_agent_def.yaml
@@ -1,0 +1,13 @@
+name: dummy_agent
+kind: Agent
+version: 1.0.0
+description: random text
+in_selectors:
+  - a.b.c
+out_selectors: [ ]
+docker_file_path: ./assets/dummyagentDockerfile
+docker_build_root: ./
+args:
+  - name: test
+    type: test
+    description: test

--- a/tests/cli/agent/build/build_test.py
+++ b/tests/cli/agent/build/build_test.py
@@ -1,6 +1,6 @@
 """Tests for CLI agent build command."""
 
-from pathlib import Path
+import pathlib
 
 import docker
 import pytest
@@ -34,7 +34,7 @@ def _is_docker_image_present(image: str):
 def testAgentBuildCLI_whenParentBuildRootPath_failShowErrorMessage():
     """Test oxo agent build CLI command : Case where the command is valid. The agent container should be built."""
     dummy_def_yaml_file_path = (
-        Path(__file__).parent / "assets/illegal_build_root_dummydef.yaml"
+            pathlib.Path(__file__).parent / "assets/illegal_build_root_dummydef.yaml"
     )
     runner = testing.CliRunner()
     result = runner.invoke(
@@ -56,7 +56,7 @@ def testAgentBuildCLI_whenCommandIsValid_buildCompletedAndNoRaiseImageNotFoundEx
 ):
     """Test oxo agent build CLI command : Case where the command is valid. The agent container should be built."""
     del image_cleanup
-    dummy_def_yaml_file_path = Path(__file__).parent / "assets/dummydef.yaml"
+    dummy_def_yaml_file_path = pathlib.Path(__file__).parent / "assets/dummydef.yaml"
     runner = testing.CliRunner()
     _ = runner.invoke(
         rootcli.rootcli,
@@ -77,7 +77,7 @@ def testAgentBuildCLI_whenCommandIsValidAndImageAlreadyExists_showsMessageAndExi
 ):
     """Test oxo agent build CLI command : Case where the command is valid. The agent container should be built."""
     del image_cleanup
-    dummy_def_yaml_file_path = Path(__file__).parent / "assets/dummydef.yaml"
+    dummy_def_yaml_file_path = pathlib.Path(__file__).parent / "assets/dummydef.yaml"
     runner = testing.CliRunner()
     _ = runner.invoke(
         rootcli.rootcli,
@@ -110,7 +110,7 @@ def testAgentBuildCLI_whenImageAlreadyExistsAndForceFlagPassed_buildCompletedAnd
     passed. The agent container should be built.
     """
     del image_cleanup
-    dummy_def_yaml_file_path = Path(__file__).parent / "assets/dummydef.yaml"
+    dummy_def_yaml_file_path = pathlib.Path(__file__).parent / "assets/dummydef.yaml"
     runner = testing.CliRunner()
     _ = runner.invoke(
         rootcli.rootcli,
@@ -133,3 +133,26 @@ def testAgentBuildCLI_whenImageAlreadyExistsAndForceFlagPassed_buildCompletedAnd
     )
     assert "already exist" not in result.output
     assert result.exit_code == 0
+
+
+def testAgentBuildCLI_whenAgentDefinitionHasInvalidArgType_failShowErrorMessage():
+    """Test oxo agent build CLI command : Case where the agent definition file has an invalid arg type."""
+    invalid_agent_def = (
+            pathlib.Path(__file__).parent / "assets/invalid_agent_def.yaml"
+    )
+    runner = testing.CliRunner()
+
+    result = runner.invoke(
+        rootcli.rootcli,
+        [
+            "agent",
+            "build",
+            f"--file={invalid_agent_def}",
+            "--organization=ostorlab",
+        ],
+    )
+
+    assert result.output == ('🔺 ERROR: Definition file does not conform to the provided specification: \n'
+                             "Validation did not pass: 'test' is not one of ['string', 'number', "
+                             "'boolean', \n"
+                             "'array', 'object'] for field properties.args.items.properties.type.enum.\n")

--- a/tests/cli/agent/build/build_test.py
+++ b/tests/cli/agent/build/build_test.py
@@ -34,7 +34,7 @@ def _is_docker_image_present(image: str):
 def testAgentBuildCLI_whenParentBuildRootPath_failShowErrorMessage():
     """Test oxo agent build CLI command : Case where the command is valid. The agent container should be built."""
     dummy_def_yaml_file_path = (
-            pathlib.Path(__file__).parent / "assets/illegal_build_root_dummydef.yaml"
+        pathlib.Path(__file__).parent / "assets/illegal_build_root_dummydef.yaml"
     )
     runner = testing.CliRunner()
     result = runner.invoke(
@@ -135,11 +135,11 @@ def testAgentBuildCLI_whenImageAlreadyExistsAndForceFlagPassed_buildCompletedAnd
     assert result.exit_code == 0
 
 
-def testAgentBuildCLI_whenAgentDefinitionHasInvalidArgType_failShowErrorMessage():
+def testAgentBuildCLI_whenAgentDefinitionHasInvalidArgType_failShowErrorMessage() -> (
+    None
+):
     """Test oxo agent build CLI command : Case where the agent definition file has an invalid arg type."""
-    invalid_agent_def = (
-            pathlib.Path(__file__).parent / "assets/invalid_agent_def.yaml"
-    )
+    invalid_agent_def = pathlib.Path(__file__).parent / "assets/invalid_agent_def.yaml"
     runner = testing.CliRunner()
 
     result = runner.invoke(
@@ -152,7 +152,9 @@ def testAgentBuildCLI_whenAgentDefinitionHasInvalidArgType_failShowErrorMessage(
         ],
     )
 
-    assert result.output == ('🔺 ERROR: Definition file does not conform to the provided specification: \n'
-                             "Validation did not pass: 'test' is not one of ['string', 'number', "
-                             "'boolean', \n"
-                             "'array', 'object'] for field properties.args.items.properties.type.enum.\n")
+    assert result.output == (
+        "🔺 ERROR: Definition file does not conform to the provided specification: \n"
+        "Validation did not pass: 'test' is not one of ['string', 'number', "
+        "'boolean', \n"
+        "'array', 'object'] for field properties.args.items.properties.type.enum.\n"
+    )


### PR DESCRIPTION
### Changes Made

- Updated `agent_schema.json` and `agent_group_schema.json` to enforce argument type validation during agent definition construction.

### How This Was Identified

While attempting to build an agent with the following configuration file:

```yaml
kind: Agent
name: template_agent # Agent name, must be unique by organisation to be published on the store.
version: 0.0.0 # Must respect semantic versioning.
description: Agent description. # Supports Markdown format.
in_selectors: # List of input selectors; essentially, the list of messages the agent should receive.
  - v3.healthcheck.ping
out_selectors: [] # List of output selectors.
docker_file_path: Dockerfile # Dockerfile path for automated releases.
docker_build_root: . # Docker build directory for automated release builds.
args: # List of arguments the agent can take.
  - name: test # Argument name.
    type: test # Argument type.
    description: test # Argument description.
```

The build process did not raise any errors related to argument type validation:

![image](https://github.com/user-attachments/assets/44aaab42-a2f4-48e6-93e4-c88193a992f5)

### Result After Adding Extra Checks

After implementing additional argument type checks, the validation errors are now properly detected:

![image](https://github.com/user-attachments/assets/ca5f9579-8f6d-44da-9462-d9f5ab2e993d)
