### PR TITLE
Fix broken OXO standalone binary

### DIFF
--- a/.github/workflows/release_linux_mac_bin.yaml
+++ b/.github/workflows/release_linux_mac_bin.yaml
@@ -48,7 +48,7 @@ jobs:
         pip install pyinstaller
 
     - run: |
-        pyinstaller --name oxo_${{ matrix.os }} --onefile --add-data="./*:." --hidden-import alembic --hidden-import docker --hidden-import click src/ostorlab/main.py
+        pyinstaller --name oxo_${{ matrix.os }} --onefile --add-data="./*:." --collect-all pyaxmlparser --hidden-import alembic --hidden-import docker --hidden-import click src/ostorlab/main.py
     - name: Release
       uses: softprops/action-gh-release@v2
       with:

--- a/.github/workflows/release_windows_bin.yaml
+++ b/.github/workflows/release_windows_bin.yaml
@@ -47,7 +47,7 @@ jobs:
         pip install pyinstaller
 
     - run: |
-        pyinstaller --name oxo_${{ matrix.os }} --onefile --add-data="./*:." --hidden-import alembic --hidden-import docker --hidden-import click src/ostorlab/main.py
+        pyinstaller --name oxo_${{ matrix.os }} --onefile --add-data="./*:." --collect-all pyaxmlparser --hidden-import alembic --hidden-import docker --hidden-import click src/ostorlab/main.py
     - name: Release
       uses: softprops/action-gh-release@v2
       with:


### PR DESCRIPTION
The `OXO` binary was broken since this release [v1.0.25](https://github.com/Ostorlab/oxo/releases/tag/v1.0.25) because of `pyaxmlparser` library since it is trying to access `public.xml` file but it is missing 
![image](https://github.com/user-attachments/assets/ea727866-df80-46fb-a675-f9f9e460fe65)
In this pull request, I'm adding `--collect-all pyaxmlparser` since the `pyinstaller` documentation states that it collects all submodules, data files, and binaries from the specified package or module.
![image](https://github.com/user-attachments/assets/7830ba6b-0f22-4df8-b822-09c6d79a496e)
