### PR TITLE
Fix emitting non-exact out selectors.

### DIFF
--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -372,10 +372,10 @@ class AgentMixin(
             None
         """
         if (
-            any(
-                out_selector.startswith(selector) for out_selector in self.out_selectors
+            all(
+                selector.startswith(out_selector) for out_selector in self.out_selectors
             )
-            is True
+            is False
         ):
             logger.error("selector not present in list of out selectors")
             # CAUTION: this check is enforced on the client-side only in certain runtimes

--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -371,7 +371,12 @@ class AgentMixin(
         Returns:
             None
         """
-        if selector not in self.out_selectors:
+        if (
+            any(
+                out_selector.startswith(selector) for out_selector in self.out_selectors
+            )
+            is True
+        ):
             logger.error("selector not present in list of out selectors")
             # CAUTION: this check is enforced on the client-side only in certain runtimes
             raise NonListedMessageSelectorError(

--- a/tests/agent/agent_test.py
+++ b/tests/agent/agent_test.py
@@ -944,7 +944,7 @@ def testProcessMessage_whenAgentSettingsInSelectorsSet_shouldUseAgentSettingsInS
 def testEmit_whenOutSelectorIsNotExact_emitsMessage(
     agent_run_mock: agent_testing.AgentRunInstance,
 ) -> None:
-    """Test emit is adding the agent in the control message."""
+    """Test emit when out-selector is the message parent."""
 
     class TestAgent(agent.Agent):
         """Helper class to test OpenTelemetry mixin implementation."""
@@ -978,7 +978,7 @@ def testEmit_whenOutSelectorIsNotExact_emitsMessage(
 def testEmit_whenOutSelectorIsNotParent_dontEmitMessage(
     agent_run_mock: agent_testing.AgentRunInstance,
 ) -> None:
-    """Test emit is adding the agent in the control message."""
+    """Test emit when out-selector is not the message parent."""
 
     class TestAgent(agent.Agent):
         """Helper class to test OpenTelemetry mixin implementation."""


### PR DESCRIPTION
`out-selectors` enable a hierarchical logic to receive and emit messages. If an agent list listens to `v3.report` then he will receive all messages like `v3.report`, `v3.report.vulnerability`, `v3.report.xxx`.

If an agent states `out-selector`, he should in the same fashion be able to emit all sub-messages.

The current implementation was doing an exact match:

```python
ostorlab.agent.agent.NonListedMessageSelectorError
```

Fix switch to `startswith` check:
```python
        if (
            any(
                out_selector.startswith(selector) for out_selector in self.out_selectors
            )
            is True
        ):
```.

Unit test checks for both should and should not emit case.