### PR TITLE
Check selector in list selectors

### DIFF
--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -372,7 +372,7 @@ class AgentMixin(
             None
         """
         if (
-            all(
+            any(
                 selector.startswith(out_selector) for out_selector in self.out_selectors
             )
             is False


### PR DESCRIPTION
Fixing the current check.

 if the selector is 'v3.report.vulnerability' and the agent selectors is out_selectors = ['v3.report.vulnerability', 'v3.capture.stack_trace']. 

We should raise an exception if any (selector does match out_selectors) returns False. it means for all the elements in out_selectors none of them matches selectors.