### PR TITLE
Support Arguments with Colons in Their Values

### DIFF
--- a/src/ostorlab/cli/types.py
+++ b/src/ostorlab/cli/types.py
@@ -42,7 +42,7 @@ class AgentArgType(click.ParamType):
             click.BadParameter: If the argument value cannot be parsed into the expected format.
         """
         try:
-            arg_name, arg_value = arg_value.split(":")
+            arg_name, arg_value = arg_value.split(":", 1)
             return AgentArg(name=arg_name, value=arg_value)
         except ValueError:
             self.fail(

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -391,6 +391,27 @@ def testOstorlabScanRunCLI_whenWrongArgsFormatProvided_showsErrorMessage() -> No
     )
 
 
+def testOstorlabScanRunCLI_whenAgentArgContainsThreeColons_doesNotCrash(
+    mocker: plugin.MockerFixture,
+) -> None:
+    mocker.patch("ostorlab.runtimes.local.LocalRuntime.__init__", return_value=None)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        rootcli.rootcli,
+        [
+            "scan",
+            "run",
+            "--agent=agent/ostorlab/nmap",
+            "--arg=proxy:arg_value:http://localhost:3000/",
+            "ip",
+            "8.8.8.8",
+        ],
+    )
+
+    assert result.output == ""
+
+
 @pytest.mark.parametrize(
     "invalid_agent_key", ["/nmap", "@agent/ostorlab/nmap/", "agent/ostorlab/nmap/"]
 )

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -391,28 +391,6 @@ def testOstorlabScanRunCLI_whenWrongArgsFormatProvided_showsErrorMessage() -> No
     )
 
 
-def testOstorlabScanRunCLI_whenAgentArgContainsThreeColons_doesNotCrash(
-    mocker: plugin.MockerFixture,
-) -> None:
-    mocker.patch("ostorlab.runtimes.local.LocalRuntime.__init__", return_value=None)
-    mocker.patch("ostorlab.runtimes.local.LocalRuntime.can_run", return_value=True)
-    runner = CliRunner()
-
-    result = runner.invoke(
-        rootcli.rootcli,
-        [
-            "scan",
-            "run",
-            "--agent=agent/ostorlab/nmap",
-            "--arg=proxy:arg_value:http://localhost:3000/",
-            "ip",
-            "8.8.8.8",
-        ],
-    )
-
-    assert result.output == ""
-
-
 @pytest.mark.parametrize(
     "invalid_agent_key", ["/nmap", "@agent/ostorlab/nmap/", "agent/ostorlab/nmap/"]
 )

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -395,6 +395,7 @@ def testOstorlabScanRunCLI_whenAgentArgContainsThreeColons_doesNotCrash(
     mocker: plugin.MockerFixture,
 ) -> None:
     mocker.patch("ostorlab.runtimes.local.LocalRuntime.__init__", return_value=None)
+    mocker.patch("ostorlab.runtimes.local.LocalRuntime.can_run", return_value=True)
     runner = CliRunner()
 
     result = runner.invoke(


### PR DESCRIPTION
### Summary

This PR fixes an issue with handling argument values containing colons (`:`) when constructing arguments. Previously, arguments with colons in their values were not processed correctly, leading to unexpected behavior. 

#### Before Fix:

![Before Fix](https://github.com/user-attachments/assets/39a1e6dd-d1b1-439f-aab1-b14fb6fee210)

#### After Fix:


![After Fix](https://github.com/user-attachments/assets/cb777b65-e917-47b1-ad6b-b349c2ae9f35)

