### PR TITLE
Stop scan crashing when casting none to int

### DIFF
--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -309,9 +309,13 @@ class LocalRuntime(runtime.Runtime):
         networks = self._docker_client.networks.list()
         for network in networks:
             network_labels = network.attrs["Labels"]
+            if network_labels is None:
+                continue
+            universe = network_labels.get("ostorlab.universe")
             if (
-                network_labels is not None
-                and int(network_labels.get("ostorlab.universe")) == scan_id
+                universe is not None
+                and network_labels is not None
+                and int(universe) == scan_id
             ):
                 logger.info("removing network %s", network_labels)
                 stopped_network.append(network)

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -310,12 +310,14 @@ class LocalRuntime(runtime.Runtime):
         for network in networks:
             network_labels = network.attrs["Labels"]
             if network_labels is None:
+                logger.debug("Skipping network with no labels")
                 continue
-            universe = network_labels.get("ostorlab.universe")
-            if universe is not None and int(universe) == scan_id:
-                logger.info("removing network %s", network_labels)
-                stopped_network.append(network)
-                network.remove()
+            if isinstance(network_labels, dict):
+                universe = network_labels.get("ostorlab.universe")
+                if universe is not None and int(universe) == scan_id:
+                    logger.info("removing network %s", network_labels)
+                    stopped_network.append(network)
+                    network.remove()
 
         configs = self._docker_client.configs.list()
         for config in configs:

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -312,11 +312,7 @@ class LocalRuntime(runtime.Runtime):
             if network_labels is None:
                 continue
             universe = network_labels.get("ostorlab.universe")
-            if (
-                universe is not None
-                and network_labels is not None
-                and int(universe) == scan_id
-            ):
+            if universe is not None and int(universe) == scan_id:
                 logger.info("removing network %s", network_labels)
                 stopped_network.append(network)
                 network.remove()

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -369,7 +369,7 @@ def testCheckServicesMethod_whenServicesAreStopped_shouldExit(
 
 @pytest.mark.docker
 def testRuntimeScanStop_whenUnrelatedNetworks_removesScanServiceWithoutCrash(
-    mocker, db_engine_path
+    mocker: plugin.MockerFixture, db_engine_path: str
 ):
     """Unittest for the scan stop method when there are networks not related to the scan, the process shouldn't crash"""
     mocker.patch.object(models, "ENGINE_URL", db_engine_path)

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -375,7 +375,7 @@ def testRuntimeScanStop_whenUnrelatedNetworks_RemovesScanServiceWithoutCrash(
     mocker.patch.object(models, "ENGINE_URL", db_engine_path)
     create_scan_db = models.Scan.create("test")
 
-    def docker_services():
+    def docker_services() -> list[services_model.Service]:
         """Method for mocking the services list response."""
         with models.Database() as session:
             scan = session.query(models.Scan).first()
@@ -394,7 +394,7 @@ def testRuntimeScanStop_whenUnrelatedNetworks_RemovesScanServiceWithoutCrash(
 
         return [services_model.Service(attrs=service) for service in services]
 
-    def docker_networks():
+    def docker_networks() -> list[networks_model.Network]:
         """Method for mocking the services list response."""
         with models.Database() as session:
             scan = session.query(models.Scan).first()
@@ -402,12 +402,12 @@ def testRuntimeScanStop_whenUnrelatedNetworks_RemovesScanServiceWithoutCrash(
             {
                 "ID": "0099i5n1y3gycuekvksyqyxav",
                 "CreatedAt": "2021-12-27T13:37:02.795789947Z",
-                "Labels": {"ostorlab.universe": scan.id},
+                "Labels": {},
             },
             {
                 "ID": "0099i5n1y3gycuekvksyqyxav",
                 "CreatedAt": "2021-12-27T13:37:02.795789947Z",
-                "Labels": {},
+                "Labels": {"ostorlab.universe": scan.id},
             },
         ]
 

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -368,7 +368,7 @@ def testCheckServicesMethod_whenServicesAreStopped_shouldExit(
 
 
 @pytest.mark.docker
-def testRuntimeScanStop_whenUnrelatedNetworks_RemovesScanServiceWithoutCrash(
+def testRuntimeScanStop_whenUnrelatedNetworks_removesScanServiceWithoutCrash(
     mocker, db_engine_path
 ):
     """Unittest for the scan stop method when there are networks not related to the scan, the process shouldn't crash"""


### PR DESCRIPTION
In the stop scan, we list all the networks and attempt to retrieve `ostorlab.universe` from each network, casting it to an integer. However, this approach fails because there are networks that are not related to the `scan universe` and do not contain `ostorlab.universe`. This pull request refactors the code to first check if a network has `ostorlab.universe` before proceeding with the casting.