### PR TITLE
 Add CI/CD parameters to scan creation API and CLI

### DIFF
--- a/src/ostorlab/apis/scan_create.py
+++ b/src/ostorlab/apis/scan_create.py
@@ -10,8 +10,8 @@ from . import request
 
 
 @dataclasses.dataclass
-class CiCdParams:
-    """Dataclass holding CI/CD related parameters."""
+class ScanSource:
+    """Dataclass holding scan source related parameters."""
 
     source: str
     repository: Optional[str] = None
@@ -45,7 +45,7 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         application: BinaryIO,
         test_credential_ids: Optional[List[int]] = None,
         sboms: list[io.FileIO] = None,
-        ci_cd_params: Optional[CiCdParams] = None,
+        ci_cd_params: Optional[ScanSource] = None,
     ):
         self._title = title
         self._asset_type = asset_type

--- a/src/ostorlab/apis/scan_create.py
+++ b/src/ostorlab/apis/scan_create.py
@@ -15,7 +15,7 @@ class CiCdParams:
 
     source: str
     repository: Optional[str] = None
-    pr_id: Optional[str] = None
+    pr_number: Optional[str] = None
 
 
 SCAN_PROFILES = {
@@ -53,7 +53,7 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         self._application = application
         self._test_credential_ids = test_credential_ids
         self._sboms = sboms
-        self._ci_cd_params = ci_cd_params or CiCdParams()
+        self._ci_cd_params = ci_cd_params
 
     @property
     def query(self) -> Optional[str]:
@@ -64,8 +64,8 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         """
 
         return """
-mutation MobileScan($title: String!, $assetType: String!, $application: Upload!, $sboms: [Upload!], $scanProfile: String!, $credentialIds: [Int], $ciCdSource: String, $prId: String, $repository: String) {
-  createMobileScan(title: $title, assetType: $assetType, application: $application, sboms: $sboms, scanProfile: $scanProfile, credentialIds: $credentialIds, ciCdSource: $ciCdSource, prId: $prId, repository: $repository) {
+mutation MobileScan($title: String!, $assetType: String!, $application: Upload!, $sboms: [Upload!], $scanProfile: String!, $credentialIds: [Int], $scanSource: ScanSourceInputType) {
+  createMobileScan(title: $title, assetType: $assetType, application: $application, sboms: $sboms, scanProfile: $scanProfile, credentialIds: $credentialIds, scanSource: $scanSource) {
     scan {
       id
     }
@@ -96,9 +96,11 @@ mutation MobileScan($title: String!, $assetType: String!, $application: Upload!,
                         "scanProfile": self._scan_profile,
                         "credentialIds": self._test_credential_ids,
                         "sboms": [None for _ in self._sboms],
-                        "ciCdSource": self._ci_cd_params.source,
-                        "repository": self._ci_cd_params.repository,
-                        "prId": self._ci_cd_params.pr_id,
+                        "scanSource": {
+                            "source": self._ci_cd_params.source,
+                            "repository": self._ci_cd_params.repository,
+                            "prNumber": self._ci_cd_params.pr_number,
+                        },
                     },
                 }
             ),

--- a/src/ostorlab/apis/scan_create.py
+++ b/src/ostorlab/apis/scan_create.py
@@ -45,7 +45,7 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         application: BinaryIO,
         test_credential_ids: Optional[List[int]] = None,
         sboms: list[io.FileIO] = None,
-        ci_cd_params: Optional[ScanSource] = None,
+        scan_source: Optional[ScanSource] = None,
     ):
         self._title = title
         self._asset_type = asset_type
@@ -53,7 +53,7 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         self._application = application
         self._test_credential_ids = test_credential_ids
         self._sboms = sboms
-        self._ci_cd_params = ci_cd_params
+        self._scan_source = scan_source
 
     @property
     def query(self) -> Optional[str]:
@@ -97,9 +97,15 @@ mutation MobileScan($title: String!, $assetType: String!, $application: Upload!,
                         "credentialIds": self._test_credential_ids,
                         "sboms": [None for _ in self._sboms],
                         "scanSource": {
-                            "source": self._ci_cd_params.source,
-                            "repository": self._ci_cd_params.repository,
-                            "prNumber": self._ci_cd_params.pr_number,
+                            "source": self._scan_source.source
+                            if self._scan_source is not None
+                            else None,
+                            "repository": self._scan_source.repository
+                            if self._scan_source is not None
+                            else None,
+                            "prNumber": self._scan_source.pr_number
+                            if self._scan_source is not None
+                            else None,
                         },
                     },
                 }

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -65,7 +65,7 @@ def run_mobile_scan(
         sboms = ctx.obj["sboms"]
         repository = ctx.obj["repository"]
         source = ctx.obj["source"]
-        pr_id = ctx.obj["pr_id"]
+        pr_number = ctx.obj["pr_number"]
         runner = authenticated_runner.AuthenticatedAPIRunner(
             api_key=ctx.obj.get("api_key")
         )
@@ -85,7 +85,7 @@ def run_mobile_scan(
             ci_cd_params = None
             if source is not None:
                 ci_cd_params = scan_create_api.CiCdParams(
-                    source=source, repository=repository, pr_id=pr_id
+                    source=source, repository=repository, pr_number=pr_number
                 )
 
             scan_id = _create_scan(

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -84,7 +84,7 @@ def run_mobile_scan(
             )
             ci_cd_params = None
             if source is not None:
-                ci_cd_params = scan_create_api.CiCdParams(
+                ci_cd_params = scan_create_api.ScanSource(
                     source=source, repository=repository, pr_number=pr_number
                 )
 
@@ -126,7 +126,7 @@ def _create_scan(
     credential_ids: List[int],
     runner: authenticated_runner.AuthenticatedAPIRunner,
     sboms: List[io.FileIO],
-    ci_cd_params: Optional[scan_create_api.CiCdParams] = None,
+    ci_cd_params: Optional[scan_create_api.ScanSource] = None,
 ) -> int:
     scan_result = runner.execute(
         scan_create_api.CreateMobileScanAPIRequest(

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -82,9 +82,9 @@ def run_mobile_scan(
             ci_logger.info(
                 f"creating scan `{title}` with profile `{scan_profile}` for `{asset_type}`"
             )
-            ci_cd_params = None
+            scan_source = None
             if source is not None:
-                ci_cd_params = scan_create_api.ScanSource(
+                scan_source = scan_create_api.ScanSource(
                     source=source, repository=repository, pr_number=pr_number
                 )
 
@@ -96,7 +96,7 @@ def run_mobile_scan(
                 credential_ids,
                 runner,
                 sboms,
-                ci_cd_params,
+                scan_source,
             )
 
             ci_logger.output(name="scan_id", value=scan_id)
@@ -126,7 +126,7 @@ def _create_scan(
     credential_ids: List[int],
     runner: authenticated_runner.AuthenticatedAPIRunner,
     sboms: List[io.FileIO],
-    ci_cd_params: Optional[scan_create_api.ScanSource] = None,
+    scan_source: Optional[scan_create_api.ScanSource] = None,
 ) -> int:
     scan_result = runner.execute(
         scan_create_api.CreateMobileScanAPIRequest(
@@ -136,7 +136,7 @@ def _create_scan(
             application=file,
             test_credential_ids=credential_ids,
             sboms=sboms,
-            ci_cd_params=ci_cd_params,
+            scan_source=scan_source,
         )
     )
     scan_id = scan_result.get("data").get("createMobileScan").get("scan").get("id")

--- a/src/ostorlab/cli/ci_scan/run/run.py
+++ b/src/ostorlab/cli/ci_scan/run/run.py
@@ -140,8 +140,8 @@ CI_LOGGER = {
     default=None,
 )
 @click.option(
-    "--pr-id",
-    help="Pull request ID.",
+    "--pr-number",
+    help="Pull request number.",
     required=False,
     default=None,
 )
@@ -166,7 +166,7 @@ def run(
     qps: int,
     source: Optional[str] = None,
     repository: Optional[str] = None,
-    pr_id: Optional[str] = None,
+    pr_number: Optional[str] = None,
 ) -> None:
     """Start a scan based on a scan profile in the CI.\n"""
 
@@ -218,7 +218,7 @@ def run(
     ctx.obj["qps"] = qps
     ctx.obj["source"] = source
     ctx.obj["repository"] = repository
-    ctx.obj["pr_id"] = pr_id
+    ctx.obj["pr_number"] = pr_number
 
 
 def apply_break_scan_risk_rating(

--- a/src/ostorlab/cli/ci_scan/run/run.py
+++ b/src/ostorlab/cli/ci_scan/run/run.py
@@ -8,7 +8,7 @@ import io
 import multiprocessing
 import click
 import time
-from typing import List
+from typing import List, Optional
 
 from ostorlab.cli.ci_scan.ci_scan import ci_scan
 from ostorlab.apis import scan_create as scan_create_api
@@ -127,6 +127,24 @@ CI_LOGGER = {
     required=False,
     default=None,
 )
+@click.option(
+    "--source",
+    help="CI/CD source.",
+    required=False,
+    default=None,
+)
+@click.option(
+    "--repository",
+    help="Repository name.",
+    required=False,
+    default=None,
+)
+@click.option(
+    "--pr-id",
+    help="Pull request ID.",
+    required=False,
+    default=None,
+)
 @click.pass_context
 def run(
     ctx: click.core.Context,
@@ -146,6 +164,9 @@ def run(
     filtered_url_regexes: List[str],
     proxy: str,
     qps: int,
+    source: Optional[str] = None,
+    repository: Optional[str] = None,
+    pr_id: Optional[str] = None,
 ) -> None:
     """Start a scan based on a scan profile in the CI.\n"""
 
@@ -195,6 +216,9 @@ def run(
     ctx.obj["filtered_url_regexes"] = filtered_url_regexes
     ctx.obj["proxy"] = proxy
     ctx.obj["qps"] = qps
+    ctx.obj["source"] = source
+    ctx.obj["repository"] = repository
+    ctx.obj["pr_id"] = pr_id
 
 
 def apply_break_scan_risk_rating(

--- a/tests/cli/ci_scan/run/run_test.py
+++ b/tests/cli/ci_scan/run/run_test.py
@@ -426,7 +426,7 @@ def testRunWebScanCLI_withsboms_callApi(
     assert api_caller_mock.call_count == 2
 
 
-def testRunScanCLI_whithSourceGithub_callApi(mocker):
+def testRunScanCLI_whithSourceGithub_callApi(mocker: plugin.MockerFixture) -> None:
     """Test ostorlab ci_scan with invalid break_on_risk_rating. it should exit with error exit_code = 2."""
     scan_create_dict = {"data": {"createMobileScan": {"scan": {"id": "1"}}}}
 
@@ -459,7 +459,7 @@ def testRunScanCLI_whithSourceGithub_callApi(mocker):
             "--log-flavor=github",
             "--source=github",
             "--repository=org/repo",
-            "--pr-id=123456",
+            "--pr-number=123456",
             "ios-ipa",
             TEST_FILE_PATH,
         ],
@@ -470,4 +470,4 @@ def testRunScanCLI_whithSourceGithub_callApi(mocker):
     assert (
         api_caller_mock.call_args_list[0].args[0]._ci_cd_params.repository == "org/repo"
     )
-    assert api_caller_mock.call_args_list[0].args[0]._ci_cd_params.pr_id == "123456"
+    assert api_caller_mock.call_args_list[0].args[0]._ci_cd_params.pr_number == "123456"

--- a/tests/cli/ci_scan/run/run_test.py
+++ b/tests/cli/ci_scan/run/run_test.py
@@ -466,8 +466,8 @@ def testRunScanCLI_withSourceGithub_callApi(mocker: plugin.MockerFixture) -> Non
     )
 
     assert api_caller_mock.call_count == 2
-    assert api_caller_mock.call_args_list[0].args[0]._ci_cd_params.source == "github"
+    assert api_caller_mock.call_args_list[0].args[0]._scan_source.source == "github"
     assert (
-        api_caller_mock.call_args_list[0].args[0]._ci_cd_params.repository == "org/repo"
+        api_caller_mock.call_args_list[0].args[0]._scan_source.repository == "org/repo"
     )
-    assert api_caller_mock.call_args_list[0].args[0]._ci_cd_params.pr_number == "123456"
+    assert api_caller_mock.call_args_list[0].args[0]._scan_source.pr_number == "123456"

--- a/tests/cli/ci_scan/run/run_test.py
+++ b/tests/cli/ci_scan/run/run_test.py
@@ -426,7 +426,7 @@ def testRunWebScanCLI_withsboms_callApi(
     assert api_caller_mock.call_count == 2
 
 
-def testRunScanCLI_whithSourceGithub_callApi(mocker: plugin.MockerFixture) -> None:
+def testRunScanCLI_withSourceGithub_callApi(mocker: plugin.MockerFixture) -> None:
     """Test ostorlab ci_scan with invalid break_on_risk_rating. it should exit with error exit_code = 2."""
     scan_create_dict = {"data": {"createMobileScan": {"scan": {"id": "1"}}}}
 


### PR DESCRIPTION
The changes introduce `CI/CD` context tracking for scans initiated from `GitHub Actions` by incorporating support for `CI/CD` parameters throughout the scan creation process. A new `ScanSource` data class has been created to hold CI/CD-related information, including the source, repository, and pull request ID. Additionally, the mobile scan API request has been updated to accept and include these parameters in the `GraphQL` query and its variables.


## Changed files
### scan_create.py:                                                                                                                                                                                                                                                  

 • Added ScanSource dataclass to hold CI/CD related parameters (source, repository, pr_id)                                                                                                                                                                          
 • Updated CreateMobileScanAPIRequest to:                                                                                                                                                                                                                           
    • Accept ci_cd_params parameter                                                                                                                                                                                                                                 
    • Include CI/CD parameters in GraphQL query and variables                                                                                                                                                                                                       
    • Pass CI/CD params to API request data                                                                                                                                                                                                                         

### run.py:                                                                                                                                                                                                                                                          

 • Added new CLI options for CI/CD parameters:                                                                                                                                                                                                                      
    • --source: CI/CD source name                                                                                                                                                                                                                                   
    • --repository: Repository name                                                                                                                                                                                                                                 
    • --pr-number: Pull request number                                                                                                                                                                                                                                      
 • Stored CI/CD parameters in context object for passing to scan creation                                                                                                                                                                                           

### mobile.py:                                                                                                                                                                                                                                                       

 • Updated run_mobile_scan to:                                                                                                                                                                                                                                      
    • Get CI/CD params from context                                                                                                                                                                                                                                 
    • Create ScanSource instance if source is provided                                                                                                                                                                                                              
    • Pass CI/CD params to _create_scan                                                                                                                                                                                                                             
 • Updated _create_scan to:                                                                                                                                                                                                                                         
    • Accept ci_cd_params parameter                                                                                                                                                                                                                                 
    • Pass CI/CD params to API request                                                                                                                                                                                                                              