### PR TITLE
Add method to check if a key is already mapped in Redis

### DIFF
--- a/src/ostorlab/agent/mixins/agent_persist_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_persist_mixin.py
@@ -113,7 +113,7 @@ class AgentPersistMixin:
         """
         return self._redis_client.get(key)
 
-    def exists(self, key: Union[bytes, str]) -> bool:
+    def exists(self, key: bytes | str) -> bool:
         """Helper function that checks if a given key exists in the Redis database.
 
         Args:

--- a/src/ostorlab/agent/mixins/agent_persist_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_persist_mixin.py
@@ -113,6 +113,18 @@ class AgentPersistMixin:
         """
         return self._redis_client.get(key)
 
+    def exists(self, key: Union[bytes, str]) -> bool:
+        """Helper function that checks if a given key exists in the Redis database.
+
+        Args:
+            key: The key to check for existence.
+
+        Returns:
+            bool: True if the key exists, False otherwise.
+        """
+
+        return self._redis_client.exists(key) == 1
+
     def hash_add(
         self,
         hash_name: Union[bytes, str],
@@ -123,7 +135,7 @@ class AgentPersistMixin:
 
         Args:
             hash_name: Name of the hash.
-            mapping: Dict of key/value pairs that will be hadded to hash_name
+            mapping: Dict of key/value pairs that will be added to hash_name
 
         Returns:
             True if the key does not exist, False otherwise

--- a/src/ostorlab/agent/mixins/agent_persist_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_persist_mixin.py
@@ -113,7 +113,7 @@ class AgentPersistMixin:
         """
         return self._redis_client.get(key)
 
-    def exists(self, key: bytes | str) -> bool:
+    def exists(self, key: Union[bytes, str]) -> bool:
         """Helper function that checks if a given key exists in the Redis database.
 
         Args:

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -14,10 +14,10 @@ from ostorlab.runtimes import definitions as runtime_definitions
 @pytest.mark.asyncio
 @pytest.mark.docker
 async def testAgentPersistMixin_whenSetIsAdded_setIsPersisted(
-    mocker, redis_service, clean_redis_data
+    redis_service, clean_redis_data
 ):
     """Test proper storage and access of set API."""
-    del mocker, redis_service, clean_redis_data
+    del redis_service, clean_redis_data
     settings = runtime_definitions.AgentSettings(
         key="agent/ostorlab/debug", redis_url="redis://localhost:6379"
     )
@@ -46,7 +46,6 @@ async def testAgentPersistMixinExists_whenKeyExists_returnTrue(
     mocker, redis_service, clean_redis_data
 ) -> None:
     """Test proper storage and access of set API."""
-    del mocker, redis_service, clean_redis_data
     settings = runtime_definitions.AgentSettings(
         key="agent/ostorlab/debug", redis_url="redis://localhost:6379"
     )

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -42,6 +42,25 @@ async def testAgentPersistMixin_whenSetIsAdded_setIsPersisted(
 @pytest.mark.parametrize("clean_redis_data", ["redis://localhost:6379"], indirect=True)
 @pytest.mark.asyncio
 @pytest.mark.docker
+async def testAgentPersistMixinExists_whenKeyExists_returnTrue(
+    mocker, redis_service, clean_redis_data
+):
+    """Test proper storage and access of set API."""
+    del mocker, redis_service, clean_redis_data
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/debug", redis_url="redis://localhost:6379"
+    )
+    mixin = agent_persist_mixin.AgentPersistMixin(settings)
+
+    key = "thekey"
+    assert mixin.exists(key) is False
+    mixin.add(key, b"the_value")
+    assert mixin.exists(key) is True
+
+
+@pytest.mark.parametrize("clean_redis_data", ["redis://localhost:6379"], indirect=True)
+@pytest.mark.asyncio
+@pytest.mark.docker
 async def testAgentPersistMixinDeleteKey_whenKeyExists_keyIsDeleted(
     mocker, redis_service, clean_redis_data
 ):

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -44,7 +44,7 @@ async def testAgentPersistMixin_whenSetIsAdded_setIsPersisted(
 @pytest.mark.docker
 async def testAgentPersistMixinExists_whenKeyExists_returnTrue(
     mocker, redis_service, clean_redis_data
-):
+) -> None:
     """Test proper storage and access of set API."""
     del mocker, redis_service, clean_redis_data
     settings = runtime_definitions.AgentSettings(

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -45,7 +45,7 @@ async def testAgentPersistMixin_whenSetIsAdded_setIsPersisted(
 async def testAgentPersistMixinExists_whenKeyExists_returnTrue(
     mocker, redis_service, clean_redis_data
 ) -> None:
-    """Test proper storage and access of set API."""
+    """Test AgentPersistMixin exists method."""
     settings = runtime_definitions.AgentSettings(
         key="agent/ostorlab/debug", redis_url="redis://localhost:6379"
     )

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -1,6 +1,7 @@
 """Tests for AgentPersistMixin module."""
 
 import ipaddress
+from typing import Generator
 
 import pytest
 from pytest_mock import plugin
@@ -43,7 +44,8 @@ async def testAgentPersistMixin_whenSetIsAdded_setIsPersisted(
 @pytest.mark.asyncio
 @pytest.mark.docker
 async def testAgentPersistMixinExists_whenKeyExists_returnTrue(
-    mocker, redis_service, clean_redis_data
+    redis_service: Generator[None, None, None],
+    clean_redis_data: Generator[local_redis_service.LocalRedis, None, None],
 ) -> None:
     """Test AgentPersistMixin exists method."""
     settings = runtime_definitions.AgentSettings(


### PR DESCRIPTION
This PR adds a helper method `exists` in `AgentPersistMixin` to check if a key is already mapped in Redis. This is useful when the mapped value size is large and we just want to check without using it.
