### PR TITLE
Update agent_persist_mock to patch _exists method

### DIFF
--- a/src/ostorlab/testing/agent.py
+++ b/src/ostorlab/testing/agent.py
@@ -94,7 +94,7 @@ def agent_persist_mock(mocker):
         if key in storage:
             return storage[key]
 
-    def _add(key: Union[str, bytes], value: bytes):
+    def _add(key: Union[str, bytes], value: bytes) -> None:
         """Check values are present in the storage dict."""
         if isinstance(value, bytes) is False:
             value = str(value).encode()

--- a/src/ostorlab/testing/agent.py
+++ b/src/ostorlab/testing/agent.py
@@ -1,10 +1,9 @@
 """mock agent implements the required methods to test the agent's behavior without using external components."""
 
+from typing import List, Union
 import dataclasses
 
 import pytest
-
-from typing import List
 
 from ostorlab.agent.message import message as msg
 
@@ -95,7 +94,7 @@ def agent_persist_mock(mocker):
         if key in storage:
             return storage[key]
 
-    def _add(key: str | bytes, value: bytes):
+    def _add(key: Union[str, bytes], value: bytes):
         """Check values are present in the storage dict."""
         if isinstance(value, bytes) is False:
             storage[key] = str(value).encode()

--- a/src/ostorlab/testing/agent.py
+++ b/src/ostorlab/testing/agent.py
@@ -97,7 +97,7 @@ def agent_persist_mock(mocker):
     def _add(key: Union[str, bytes], value: bytes):
         """Check values are present in the storage dict."""
         if isinstance(value, bytes) is False:
-            storage[key] = str(value).encode()
+            value = str(value).encode()
         storage[key] = value
 
     def _exists(key: str) -> bool:

--- a/src/ostorlab/testing/agent.py
+++ b/src/ostorlab/testing/agent.py
@@ -100,7 +100,7 @@ def agent_persist_mock(mocker):
             value = str(value).encode()
         storage[key] = value
 
-    def _exists(key: str) -> bool:
+    def _exists(key: Union[str, bytes]) -> bool:
         """Check if thr key is present in the storage dict."""
         return key in storage
 

--- a/src/ostorlab/testing/agent.py
+++ b/src/ostorlab/testing/agent.py
@@ -95,9 +95,15 @@ def agent_persist_mock(mocker):
         if key in storage:
             return storage[key]
 
-    def _add(key, value):
+    def _add(key: str | bytes, value: bytes):
         """Check values are present in the storage dict."""
-        storage[key] = str(value).encode()
+        if isinstance(value, bytes) is False:
+            storage[key] = str(value).encode()
+        storage[key] = value
+
+    def _exists(key: str) -> bool:
+        """Check if thr key is present in the storage dict."""
+        return key in storage
 
     def _hash_add(hash_name, mapping):
         for k, v in mapping.items():
@@ -155,6 +161,10 @@ def agent_persist_mock(mocker):
     mocker.patch(
         "ostorlab.agent.mixins.agent_persist_mixin.AgentPersistMixin.add",
         side_effect=_add,
+    )
+    mocker.patch(
+        "ostorlab.agent.mixins.agent_persist_mixin.AgentPersistMixin.exists",
+        side_effect=_exists,
     )
     mocker.patch(
         "ostorlab.agent.mixins.agent_persist_mixin.AgentPersistMixin.hash_add",

--- a/tests/testing/agent_test.py
+++ b/tests/testing/agent_test.py
@@ -62,3 +62,6 @@ def testMockPersistAgent_whensetMethodsAreCalled_stateIsPersistedByMock(
     assert test_agent.set_add("test", "1") is True
     assert test_agent.set_is_member("test", "1") is True
     assert agent_persist_mock == {"test": {"1"}}
+    assert test_agent.exists("akey") is False
+    test_agent.add("akey", b"aval")
+    assert test_agent.exists("akey") is True


### PR DESCRIPTION
This PR updates `persist_agent_mock` to patch the `_exists` method that was added to the `agent_persist_mixin`.

This PR also updates the patch function `_add` to only encode the `value` argument if it is not of type `bytes`.
If `value` is of type `bytes` then we have `str(value).encode() != value`.
