### PR TITLE
Sort dna dict

### DIFF
--- a/src/ostorlab/agent/mixins/agent_report_vulnerability_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_report_vulnerability_mixin.py
@@ -6,6 +6,7 @@ and emit a vulnerability message.
 
 import dataclasses
 import enum
+import json
 from typing import Optional, List, Any, Union, Dict
 
 from ostorlab.agent.kb import kb
@@ -108,7 +109,12 @@ class AgentReportVulnMixin(emit.EmitProtocol):
         cvss_v3_vector = entry.cvss_v3_vector
         cvss_v4_vector = entry.cvss_v4_vector
         category_groups = entry.category_groups
-
+        if dna is not None:
+            try:
+                dna_dict = json.loads(dna)
+                dna = json.dumps(_sort_dict(dna_dict))
+            except json.JSONDecodeError:
+                pass
         references = []
         for key, value in entry.references.items():
             reference = {}
@@ -145,3 +151,22 @@ class AgentReportVulnMixin(emit.EmitProtocol):
 
         selector = "v3.report.vulnerability"
         self.emit(selector, data)
+
+
+def _sort_dict(dictionary: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+    """Recursively sort dictionary keys and lists within.
+    Args:
+        dictionary: The dictionary to sort.
+    Returns:
+        A sorted dictionary or list.
+    """
+    if isinstance(dictionary, dict):
+        return {k: _sort_dict(v) for k, v in sorted(dictionary.items())}
+    if isinstance(dictionary, list):
+        return sorted(
+            dictionary,
+            key=lambda x: json.dumps(x, sort_keys=True)
+            if isinstance(x, dict)
+            else str(x),
+        )
+    return dictionary

--- a/tests/agent/mixins/agent_report_vulnerability_mixin_test.py
+++ b/tests/agent/mixins/agent_report_vulnerability_mixin_test.py
@@ -201,7 +201,7 @@ def testSendVulnerabilityMessage_whenKbEntryIsValidWithCategories_emitVulnerabil
     ]
 
 
-def testSendVulnerabilityMessage_whenDnaIsDict_emitVulnerabilityMessageWithSortedDict(
+def testSendVulnerabilityMessage_whenDnaIsDict_emitVulnerabilityMessageWithSortedDNADict(
     agent_mock: list[object],
 ) -> None:
     """Prepares & emit vulnerability message with sorted dna."""

--- a/tests/agent/mixins/agent_report_vulnerability_mixin_test.py
+++ b/tests/agent/mixins/agent_report_vulnerability_mixin_test.py
@@ -199,3 +199,26 @@ def testSendVulnerabilityMessage_whenKbEntryIsValidWithCategories_emitVulnerabil
             ],
         },
     ]
+
+
+def testSendVulnerabilityMessage_whenDnaIsDict_emitVulnerabilityMessageWithSortedDict(
+    agent_mock: list[object],
+) -> None:
+    """Prepares & emit vulnerability message with sorted dna."""
+    agent_definition = agent_definitions.AgentDefinition(
+        name="some_name", out_selectors=["v3.report.vulnerability"]
+    )
+    agent_settings = runtime_definitions.AgentSettings(key="some_key")
+    report_vul_mixin = TestAgent(agent_definition, agent_settings)
+
+    report_vul_mixin.report_vulnerability(
+        entry=knowledge_base.KB.WEB_XSS,
+        technical_detail="some_technical_detail",
+        risk_rating=agent_report_vulnerability_mixin.RiskRating.CRITICAL,
+        dna='{"x": "y", "a": "b"}',
+    )
+
+    assert len(agent_mock) == 1
+    assert agent_mock[0].selector == "v3.report.vulnerability"
+    assert agent_mock[0].data["risk_rating"] == "CRITICAL"
+    assert agent_mock[0].data["dna"] == '{"a": "b", "x": "y"}'


### PR DESCRIPTION
In this PR, I've added the logic to sort the DNA dictionary to unify the sorting logic in one place and remove duplicate code, so the agent does not have to handle sorting on their side.