### PR TITLE
Add from_dict asset factory method

### DIFF
--- a/src/ostorlab/assets/agent.py
+++ b/src/ostorlab/assets/agent.py
@@ -23,6 +23,27 @@ class Agent(asset.Asset):
         else:
             return f"Agent {self.key}"
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]):
+        """Constructs an Agent asset from a dictionary."""
+
+        def to_str(value: str | bytes | None) -> str | None:
+            if value is None:
+                return None
+            if type(value) is bytes:
+                value = value.decode()
+            return str(value)
+
+        key = to_str(data.get("key"))
+        if key is None:
+            raise ValueError("key cannot be None.")
+        args = {
+            "version": to_str(data.get("version")),
+            "docker_location": to_str(data.get("docker_location")),
+            "yaml_file_location": to_str(data.get("yaml_file_location")),
+        }
+        return cls(key, **args)
+
     @property
     def proto_field(self) -> str:
         return "agent"

--- a/src/ostorlab/assets/agent.py
+++ b/src/ostorlab/assets/agent.py
@@ -1,7 +1,7 @@
 """Agent asset."""
 
 import dataclasses
-from typing import Optional
+from typing import Optional, Any
 
 from ostorlab.assets import asset
 
@@ -24,24 +24,28 @@ class Agent(asset.Asset):
             return f"Agent {self.key}"
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "Agent":
+    def from_dict(cls, data: dict[str, Any]) -> "Agent":
         """Constructs an Agent asset from a dictionary."""
 
-        def to_str(value: str | bytes | None) -> str | None:
-            if value is None:
-                return None
+        def to_str(value: Any) -> str:
             if type(value) is bytes:
-                value = value.decode()
-            return str(value)
+                return value.decode()
+            else:
+                return str(value)
 
-        key = to_str(data.get("key"))
+        key = data.get("key")
         if key is None:
-            raise ValueError("key cannot be None.")
-        args = {
-            "version": to_str(data.get("version")),
-            "docker_location": to_str(data.get("docker_location")),
-            "yaml_file_location": to_str(data.get("yaml_file_location")),
-        }
+            raise ValueError("key is missing.")
+        args = {}
+        version = data.get("version")
+        if version is not None:
+            args["version"] = to_str(version)
+        docker_location = data.get("docker_location")
+        if docker_location is not None:
+            args["docker_location"] = to_str(docker_location)
+        yaml_file_location = data.get("yaml_file_location")
+        if yaml_file_location is not None:
+            args["yaml_file_location"] = to_str(yaml_file_location)
         return cls(key, **args)
 
     @property

--- a/src/ostorlab/assets/agent.py
+++ b/src/ostorlab/assets/agent.py
@@ -24,7 +24,7 @@ class Agent(asset.Asset):
             return f"Agent {self.key}"
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]):
+    def from_dict(cls, data: dict[str, str | bytes]) -> "Agent":
         """Constructs an Agent asset from a dictionary."""
 
         def to_str(value: str | bytes | None) -> str | None:

--- a/src/ostorlab/assets/agent.py
+++ b/src/ostorlab/assets/agent.py
@@ -27,26 +27,28 @@ class Agent(asset.Asset):
     def from_dict(cls, data: dict[str, Any]) -> "Agent":
         """Constructs an Agent asset from a dictionary."""
 
-        def to_str(value: Any) -> str:
-            if type(value) is bytes:
-                return value.decode()
-            else:
-                return str(value)
-
         key = data.get("key")
         if key is None:
             raise ValueError("key is missing.")
-        args = {}
+        args = {"key": key.decode() if type(key) is bytes else key}
         version = data.get("version")
         if version is not None:
-            args["version"] = to_str(version)
+            args["version"] = version.decode() if type(version) is bytes else version
         docker_location = data.get("docker_location")
         if docker_location is not None:
-            args["docker_location"] = to_str(docker_location)
+            args["docker_location"] = (
+                docker_location.decode()
+                if type(docker_location) is bytes
+                else docker_location
+            )
         yaml_file_location = data.get("yaml_file_location")
         if yaml_file_location is not None:
-            args["yaml_file_location"] = to_str(yaml_file_location)
-        return cls(key, **args)
+            args["yaml_file_location"] = (
+                yaml_file_location.decode()
+                if type(yaml_file_location) is bytes
+                else yaml_file_location
+            )
+        return cls(**args)
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/android_aab.py
+++ b/src/ostorlab/assets/android_aab.py
@@ -1,7 +1,7 @@
 """Android .AAB asset."""
 
 import dataclasses
-from typing import Optional
+from typing import Optional, Union, cast
 
 from ostorlab.assets import asset
 
@@ -25,20 +25,22 @@ class AndroidAab(asset.Asset):
         return str_representation
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "AndroidAab":
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "AndroidAab":
         """Constructs an AndroidAab asset from a dictionary."""
 
-        def to_str(value: str | bytes | None) -> str | None:
-            if value is None:
-                return None
-            if type(value) is bytes:
-                value = value.decode()
-            return str(value)
-
-        path = to_str(data.get("path"))
-        content_url = to_str(data.get("content_url"))
+        args = {}
+        path = data.get("path")
+        if path is not None:
+            args["path"] = path.decode() if type(path) is bytes else path
+        content_url = data.get("content_url")
+        if content_url is not None:
+            args["content_url"] = (
+                content_url.decode() if type(content_url) is bytes else content_url
+            )
         content = data.get("content")
-        return cls(path=path, content=content, content_url=content_url)  # type: ignore
+        if content is not None:
+            args["content"] = cast(bytes, content)
+        return cls(**args)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/android_aab.py
+++ b/src/ostorlab/assets/android_aab.py
@@ -24,6 +24,22 @@ class AndroidAab(asset.Asset):
 
         return str_representation
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]):
+        """Constructs an AndroidAab asset from a dictionary."""
+
+        def to_str(value: str | bytes | None) -> str | None:
+            if value is None:
+                return None
+            if type(value) is bytes:
+                value = value.decode()
+            return str(value)
+
+        path = to_str(data.get("path"))
+        content_url = to_str(data.get("content_url"))
+        content = data.get("content")
+        return cls(path=path, content=content, content_url=content_url)
+
     @property
     def proto_field(self) -> str:
         return "android_aab"

--- a/src/ostorlab/assets/android_aab.py
+++ b/src/ostorlab/assets/android_aab.py
@@ -25,7 +25,7 @@ class AndroidAab(asset.Asset):
         return str_representation
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]):
+    def from_dict(cls, data: dict[str, str | bytes]) -> "AndroidAab":
         """Constructs an AndroidAab asset from a dictionary."""
 
         def to_str(value: str | bytes | None) -> str | None:
@@ -38,7 +38,7 @@ class AndroidAab(asset.Asset):
         path = to_str(data.get("path"))
         content_url = to_str(data.get("content_url"))
         content = data.get("content")
-        return cls(path=path, content=content, content_url=content_url)
+        return cls(path=path, content=content, content_url=content_url)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/android_apk.py
+++ b/src/ostorlab/assets/android_apk.py
@@ -24,6 +24,22 @@ class AndroidApk(asset.Asset):
 
         return str_representation
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]):
+        """Constructs an AndroidApk asset from a dictionary."""
+
+        def to_str(value: str | bytes | None) -> str | None:
+            if value is None:
+                return None
+            if type(value) is bytes:
+                value = value.decode()
+            return str(value)
+
+        path = to_str(data.get("path"))
+        content_url = to_str(data.get("content_url"))
+        content = data.get("content")
+        return cls(path=path, content=content, content_url=content_url)
+
     @property
     def proto_field(self) -> str:
         return "android_apk"

--- a/src/ostorlab/assets/android_apk.py
+++ b/src/ostorlab/assets/android_apk.py
@@ -25,7 +25,7 @@ class AndroidApk(asset.Asset):
         return str_representation
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]):
+    def from_dict(cls, data: dict[str, str | bytes]) -> "AndroidApk":
         """Constructs an AndroidApk asset from a dictionary."""
 
         def to_str(value: str | bytes | None) -> str | None:
@@ -38,7 +38,7 @@ class AndroidApk(asset.Asset):
         path = to_str(data.get("path"))
         content_url = to_str(data.get("content_url"))
         content = data.get("content")
-        return cls(path=path, content=content, content_url=content_url)
+        return cls(path=path, content=content, content_url=content_url)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/android_apk.py
+++ b/src/ostorlab/assets/android_apk.py
@@ -1,7 +1,7 @@
 """Android .APK asset."""
 
 import dataclasses
-from typing import Optional
+from typing import Optional, Union, cast
 
 from ostorlab.assets import asset
 
@@ -25,20 +25,22 @@ class AndroidApk(asset.Asset):
         return str_representation
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "AndroidApk":
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "AndroidApk":
         """Constructs an AndroidApk asset from a dictionary."""
 
-        def to_str(value: str | bytes | None) -> str | None:
-            if value is None:
-                return None
-            if type(value) is bytes:
-                value = value.decode()
-            return str(value)
-
-        path = to_str(data.get("path"))
-        content_url = to_str(data.get("content_url"))
+        args = {}
+        path = data.get("path")
+        if path is not None:
+            args["path"] = path.decode() if type(path) is bytes else path
+        content_url = data.get("content_url")
+        if content_url is not None:
+            args["content_url"] = (
+                content_url.decode() if type(content_url) is bytes else content_url
+            )
         content = data.get("content")
-        return cls(path=path, content=content, content_url=content_url)  # type: ignore
+        if content is not None:
+            args["content"] = cast(bytes, content)
+        return cls(**args)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/android_store.py
+++ b/src/ostorlab/assets/android_store.py
@@ -15,6 +15,16 @@ class AndroidStore(asset.Asset):
     def __str__(self) -> str:
         return f"Android Store: ({self.package_name})"
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "AndroidStore":
+        """Constructs an AndroidStore asset from a dictionary."""
+        package_name = data.get("package_name", "")
+        if type(package_name) is bytes:
+            package_name = package_name.decode()
+        if package_name == "":
+            raise ValueError("package_name is missing.")
+        return AndroidStore(package_name)
+
     @property
     def proto_field(self) -> str:
         return "android_store"

--- a/src/ostorlab/assets/android_store.py
+++ b/src/ostorlab/assets/android_store.py
@@ -1,6 +1,7 @@
 """Android store package target asset."""
 
 import dataclasses
+from typing import Union
 
 from ostorlab.assets import asset
 
@@ -16,14 +17,15 @@ class AndroidStore(asset.Asset):
         return f"Android Store: ({self.package_name})"
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "AndroidStore":
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "AndroidStore":
         """Constructs an AndroidStore asset from a dictionary."""
-        package_name = data.get("package_name", "")
-        if type(package_name) is bytes:
-            package_name = package_name.decode()
-        if package_name == "":
+        package_name = data.get("package_name")
+        if package_name is None or package_name == "":
             raise ValueError("package_name is missing.")
-        return AndroidStore(package_name)  # type: ignore
+        package_name_str = (
+            package_name.decode() if type(package_name) is bytes else package_name
+        )
+        return AndroidStore(package_name_str)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/android_store.py
+++ b/src/ostorlab/assets/android_store.py
@@ -23,7 +23,7 @@ class AndroidStore(asset.Asset):
             package_name = package_name.decode()
         if package_name == "":
             raise ValueError("package_name is missing.")
-        return AndroidStore(package_name)
+        return AndroidStore(package_name)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/api_schema.py
+++ b/src/ostorlab/assets/api_schema.py
@@ -1,7 +1,7 @@
 """API Schema asset."""
 
 import dataclasses
-from typing import Optional
+from typing import Optional, cast
 
 from ostorlab.assets import asset
 
@@ -45,9 +45,9 @@ class ApiSchema(asset.Asset):
         content = data.get("content")
         schema_type = to_str(data.get("schema_type"))
         return cls(
-            endpoint_url=endpoint_url,
-            content=content,
-            content_url=content_url,
+            endpoint_url=cast(str, endpoint_url),
+            content=content, # type: ignore
+            content_url=cast(str, content_url),
             schema_type=schema_type,
         )
 

--- a/src/ostorlab/assets/api_schema.py
+++ b/src/ostorlab/assets/api_schema.py
@@ -46,7 +46,7 @@ class ApiSchema(asset.Asset):
         schema_type = to_str(data.get("schema_type"))
         return cls(
             endpoint_url=cast(str, endpoint_url),
-            content=content, # type: ignore
+            content=content,  # type: ignore
             content_url=cast(str, content_url),
             schema_type=schema_type,
         )

--- a/src/ostorlab/assets/api_schema.py
+++ b/src/ostorlab/assets/api_schema.py
@@ -27,6 +27,30 @@ class ApiSchema(asset.Asset):
 
         return str_representation
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "ApiSchema":
+        """Constructs an ApiSchema asset from a dictionary."""
+
+        def to_str(value: str | bytes | None) -> str | None:
+            if value is None:
+                return None
+            if type(value) is bytes:
+                value = value.decode()
+            return str(value)
+
+        endpoint_url = to_str(data.get("endpoint_url", ""))
+        if endpoint_url == "":
+            raise ValueError("endpoint_url is missing.")
+        content_url = to_str(data.get("content_url"))
+        content = data.get("content")
+        schema_type = to_str(data.get("schema_type"))
+        return cls(
+            endpoint_url=endpoint_url,
+            content=content,
+            content_url=content_url,
+            schema_type=schema_type,
+        )
+
     @property
     def proto_field(self) -> str:
         return PROTO_FIELD

--- a/src/ostorlab/assets/asset.py
+++ b/src/ostorlab/assets/asset.py
@@ -26,6 +26,70 @@ class Asset(abc.ABC):
         return "asset"
 
 
+def from_dict_factory(selector: str, data: dict[str, any]) -> Asset:
+    """Factory to create asset objects from a dictionary."""
+    if "v3.asset.file" == selector:
+        from ostorlab.assets import file as file_asset
+
+        return file_asset.File.from_dict(data)
+    if "v3.asset.file.android.apk" == selector:
+        from ostorlab.assets import android_apk
+
+        return android_apk.AndroidApk.from_dict(data)
+    if "v3.asset.file.android.aab" == selector:
+        from ostorlab.assets import android_aab
+
+        return android_aab.AndroidAab.from_dict(data)
+    if "v3.asset.file.ios.ipa" == selector:
+        from ostorlab.assets import ios_ipa
+
+        return ios_ipa.IOSIpa.from_dict(data)
+    if "v3.asset.file.ios.testflight" == selector:
+        from ostorlab.assets import ios_testflight
+
+        return ios_testflight.IOSTestflight.from_dict(data)
+    if "v3.asset.file.api_schema" == selector:
+        from ostorlab.assets import api_schema
+
+        return api_schema.ApiSchema.from_dict(data)
+    if "v3.asset.agent" in selector:
+        from ostorlab.assets import agent as agent_asset
+
+        return agent_asset.Agent.from_dict(data)
+    if "v3.asset.store.android_store" == selector:
+        from ostorlab.assets import android_store
+
+        return android_store.AndroidStore.from_dict(data)
+    if "v3.asset.store.ios_store" == selector:
+        from ostorlab.assets import ios_store
+
+        return ios_store.IOSStore.from_dict(data)
+    if "v3.asset.domain_name" == selector:
+        from ostorlab.assets import domain_name
+
+        return domain_name.DomainName.from_dict(data)
+    if "v3.asset.ip" == selector:
+        from ostorlab.assets import ip as ip_asset
+
+        return ip_asset.IP.from_dict(data)
+    if "v3.asset.ip.v4" == selector:
+        from ostorlab.assets import ipv4 as ipv4_asset
+
+        return ipv4_asset.IPv4.from_dict(data)
+    if "v3.asset.ip.v6" == selector:
+        from ostorlab.assets import ipv6 as ipv6_asset
+
+        return ipv6_asset.IPv6.from_dict(data)
+    if "v3.asset.link" == selector:
+        from ostorlab.assets import link as link_asset
+
+        return link_asset.Link.from_dict(data)
+
+    raise ValueError(
+        f"Could not create asset object due to unknown selector: {selector}"
+    )
+
+
 def selector(target: str) -> Callable[[Type[Asset]], Type[Asset]]:
     """Decorator to define an asset selector for serialization.
 

--- a/src/ostorlab/assets/asset.py
+++ b/src/ostorlab/assets/asset.py
@@ -11,6 +11,74 @@ class MissingTargetSelector(exceptions.OstorlabError):
     """Missing asset selector definition."""
 
 
+class UnknownSelector(exceptions.OstorlabError):
+    """Unknown selector value."""
+
+
+def from_dict_factory(slctr: str, data: dict[str, Any]) -> "Asset":
+    """Factory to create asset objects from a dictionary."""
+    if "v3.asset.file" == slctr:
+        from ostorlab.assets import file as file_asset
+
+        return file_asset.File.from_dict(data)
+    if "v3.asset.file.android.apk" == slctr:
+        from ostorlab.assets import android_apk
+
+        return android_apk.AndroidApk.from_dict(data)
+    if "v3.asset.file.android.aab" == slctr:
+        from ostorlab.assets import android_aab
+
+        return android_aab.AndroidAab.from_dict(data)
+    if "v3.asset.file.ios.ipa" == slctr:
+        from ostorlab.assets import ios_ipa
+
+        return ios_ipa.IOSIpa.from_dict(data)
+    if "v3.asset.file.ios.testflight" == slctr:
+        from ostorlab.assets import ios_testflight
+
+        return ios_testflight.IOSTestflight.from_dict(data)
+    if "v3.asset.file.api_schema" == slctr:
+        from ostorlab.assets import api_schema
+
+        return api_schema.ApiSchema.from_dict(data)
+    if "v3.asset.agent" in slctr:
+        from ostorlab.assets import agent as agent_asset
+
+        return agent_asset.Agent.from_dict(data)
+    if "v3.asset.store.android_store" == slctr:
+        from ostorlab.assets import android_store
+
+        return android_store.AndroidStore.from_dict(data)
+    if "v3.asset.store.ios_store" == slctr:
+        from ostorlab.assets import ios_store
+
+        return ios_store.IOSStore.from_dict(data)
+    if "v3.asset.domain_name" == slctr:
+        from ostorlab.assets import domain_name
+
+        return domain_name.DomainName.from_dict(data)
+    if "v3.asset.ip" == slctr:
+        from ostorlab.assets import ip as ip_asset
+
+        return ip_asset.IP.from_dict(data)
+    if "v3.asset.ip.v4" == slctr:
+        from ostorlab.assets import ipv4 as ipv4_asset
+
+        return ipv4_asset.IPv4.from_dict(data)
+    if "v3.asset.ip.v6" == slctr:
+        from ostorlab.assets import ipv6 as ipv6_asset
+
+        return ipv6_asset.IPv6.from_dict(data)
+    if "v3.asset.link" == slctr:
+        from ostorlab.assets import link as link_asset
+
+        return link_asset.Link.from_dict(data)
+
+    raise UnknownSelector(
+        f"Could not create asset object due to unknown selector: {slctr}"
+    )
+
+
 class Asset(abc.ABC):
     """Abstract Asset class to define the scan target and its properties."""
 
@@ -24,70 +92,6 @@ class Asset(abc.ABC):
     @property
     def proto_field(self) -> str:
         return "asset"
-
-
-def from_dict_factory(selector: str, data: dict[str, Any]) -> Asset:
-    """Factory to create asset objects from a dictionary."""
-    if "v3.asset.file" == selector:
-        from ostorlab.assets import file as file_asset
-
-        return file_asset.File.from_dict(data)
-    if "v3.asset.file.android.apk" == selector:
-        from ostorlab.assets import android_apk
-
-        return android_apk.AndroidApk.from_dict(data)
-    if "v3.asset.file.android.aab" == selector:
-        from ostorlab.assets import android_aab
-
-        return android_aab.AndroidAab.from_dict(data)
-    if "v3.asset.file.ios.ipa" == selector:
-        from ostorlab.assets import ios_ipa
-
-        return ios_ipa.IOSIpa.from_dict(data)
-    if "v3.asset.file.ios.testflight" == selector:
-        from ostorlab.assets import ios_testflight
-
-        return ios_testflight.IOSTestflight.from_dict(data)
-    if "v3.asset.file.api_schema" == selector:
-        from ostorlab.assets import api_schema
-
-        return api_schema.ApiSchema.from_dict(data)
-    if "v3.asset.agent" in selector:
-        from ostorlab.assets import agent as agent_asset
-
-        return agent_asset.Agent.from_dict(data)
-    if "v3.asset.store.android_store" == selector:
-        from ostorlab.assets import android_store
-
-        return android_store.AndroidStore.from_dict(data)
-    if "v3.asset.store.ios_store" == selector:
-        from ostorlab.assets import ios_store
-
-        return ios_store.IOSStore.from_dict(data)
-    if "v3.asset.domain_name" == selector:
-        from ostorlab.assets import domain_name
-
-        return domain_name.DomainName.from_dict(data)
-    if "v3.asset.ip" == selector:
-        from ostorlab.assets import ip as ip_asset
-
-        return ip_asset.IP.from_dict(data)
-    if "v3.asset.ip.v4" == selector:
-        from ostorlab.assets import ipv4 as ipv4_asset
-
-        return ipv4_asset.IPv4.from_dict(data)
-    if "v3.asset.ip.v6" == selector:
-        from ostorlab.assets import ipv6 as ipv6_asset
-
-        return ipv6_asset.IPv6.from_dict(data)
-    if "v3.asset.link" == selector:
-        from ostorlab.assets import link as link_asset
-
-        return link_asset.Link.from_dict(data)
-
-    raise ValueError(
-        f"Could not create asset object due to unknown selector: {selector}"
-    )
 
 
 def selector(target: str) -> Callable[[Type[Asset]], Type[Asset]]:

--- a/src/ostorlab/assets/asset.py
+++ b/src/ostorlab/assets/asset.py
@@ -15,67 +15,67 @@ class UnknownSelector(exceptions.OstorlabError):
     """Unknown selector value."""
 
 
-def from_dict_factory(slctr: str, data: dict[str, Any]) -> "Asset":
+def from_dict_factory(selector: str, data: dict[str, Any]) -> "Asset":
     """Factory to create asset objects from a dictionary."""
-    if "v3.asset.file" == slctr:
+    if "v3.asset.file" == selector:
         from ostorlab.assets import file as file_asset
 
         return file_asset.File.from_dict(data)
-    if "v3.asset.file.android.apk" == slctr:
+    if "v3.asset.file.android.apk" == selector:
         from ostorlab.assets import android_apk
 
         return android_apk.AndroidApk.from_dict(data)
-    if "v3.asset.file.android.aab" == slctr:
+    if "v3.asset.file.android.aab" == selector:
         from ostorlab.assets import android_aab
 
         return android_aab.AndroidAab.from_dict(data)
-    if "v3.asset.file.ios.ipa" == slctr:
+    if "v3.asset.file.ios.ipa" == selector:
         from ostorlab.assets import ios_ipa
 
         return ios_ipa.IOSIpa.from_dict(data)
-    if "v3.asset.file.ios.testflight" == slctr:
+    if "v3.asset.file.ios.testflight" == selector:
         from ostorlab.assets import ios_testflight
 
         return ios_testflight.IOSTestflight.from_dict(data)
-    if "v3.asset.file.api_schema" == slctr:
+    if "v3.asset.file.api_schema" == selector:
         from ostorlab.assets import api_schema
 
         return api_schema.ApiSchema.from_dict(data)
-    if "v3.asset.agent" in slctr:
+    if "v3.asset.agent" in selector:
         from ostorlab.assets import agent as agent_asset
 
         return agent_asset.Agent.from_dict(data)
-    if "v3.asset.store.android_store" == slctr:
+    if "v3.asset.store.android_store" == selector:
         from ostorlab.assets import android_store
 
         return android_store.AndroidStore.from_dict(data)
-    if "v3.asset.store.ios_store" == slctr:
+    if "v3.asset.store.ios_store" == selector:
         from ostorlab.assets import ios_store
 
         return ios_store.IOSStore.from_dict(data)
-    if "v3.asset.domain_name" == slctr:
+    if "v3.asset.domain_name" == selector:
         from ostorlab.assets import domain_name
 
         return domain_name.DomainName.from_dict(data)
-    if "v3.asset.ip" == slctr:
+    if "v3.asset.ip" == selector:
         from ostorlab.assets import ip as ip_asset
 
         return ip_asset.IP.from_dict(data)
-    if "v3.asset.ip.v4" == slctr:
+    if "v3.asset.ip.v4" == selector:
         from ostorlab.assets import ipv4 as ipv4_asset
 
         return ipv4_asset.IPv4.from_dict(data)
-    if "v3.asset.ip.v6" == slctr:
+    if "v3.asset.ip.v6" == selector:
         from ostorlab.assets import ipv6 as ipv6_asset
 
         return ipv6_asset.IPv6.from_dict(data)
-    if "v3.asset.link" == slctr:
+    if "v3.asset.link" == selector:
         from ostorlab.assets import link as link_asset
 
         return link_asset.Link.from_dict(data)
 
     raise UnknownSelector(
-        f"Could not create asset object due to unknown selector: {slctr}"
+        f"Could not create asset object due to unknown selector: {selector}"
     )
 
 

--- a/src/ostorlab/assets/asset.py
+++ b/src/ostorlab/assets/asset.py
@@ -26,7 +26,7 @@ class Asset(abc.ABC):
         return "asset"
 
 
-def from_dict_factory(selector: str, data: dict[str, any]) -> Asset:
+def from_dict_factory(selector: str, data: dict[str, Any]) -> Asset:
     """Factory to create asset objects from a dictionary."""
     if "v3.asset.file" == selector:
         from ostorlab.assets import file as file_asset

--- a/src/ostorlab/assets/domain_name.py
+++ b/src/ostorlab/assets/domain_name.py
@@ -1,6 +1,7 @@
 """Domain name asset definition."""
 
 import dataclasses
+from typing import Union
 
 from ostorlab.assets import asset
 
@@ -16,14 +17,12 @@ class DomainName(asset.Asset):
         return self.name
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "DomainName":
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "DomainName":
         """Constructs an DomainName asset from a dictionary."""
         name = data.get("name", "")
-        if type(name) is bytes:
-            name = name.decode()
         if name == "":
             raise ValueError("name is missing.")
-        return DomainName(name)  # type: ignore
+        return DomainName(name.decode() if type(name) is bytes else name)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/domain_name.py
+++ b/src/ostorlab/assets/domain_name.py
@@ -15,6 +15,16 @@ class DomainName(asset.Asset):
     def __str__(self) -> str:
         return self.name
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "DomainName":
+        """Constructs an DomainName asset from a dictionary."""
+        name = data.get("name", "")
+        if type(name) is bytes:
+            name = name.decode()
+        if name == "":
+            raise ValueError("name is missing.")
+        return DomainName(name)
+
     @property
     def proto_field(self) -> str:
         return "domain_name"

--- a/src/ostorlab/assets/domain_name.py
+++ b/src/ostorlab/assets/domain_name.py
@@ -23,7 +23,7 @@ class DomainName(asset.Asset):
             name = name.decode()
         if name == "":
             raise ValueError("name is missing.")
-        return DomainName(name)
+        return DomainName(name)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/file.py
+++ b/src/ostorlab/assets/file.py
@@ -24,6 +24,22 @@ class File(asset.Asset):
 
         return str_representation
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "File":
+        """Constructs an File asset from a dictionary."""
+
+        def to_str(value: str | bytes | None) -> str | None:
+            if value is None:
+                return None
+            if type(value) is bytes:
+                value = value.decode()
+            return str(value)
+
+        path = to_str(data.get("path"))
+        content_url = to_str(data.get("content_url"))
+        content = data.get("content")
+        return cls(path=path, content=content, content_url=content_url)
+
     @property
     def proto_field(self) -> str:
         return "file"

--- a/src/ostorlab/assets/file.py
+++ b/src/ostorlab/assets/file.py
@@ -26,7 +26,7 @@ class File(asset.Asset):
 
     @classmethod
     def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "File":
-        """Constructs an AndroidApk asset from a dictionary."""
+        """Constructs an File asset from a dictionary."""
 
         args = {}
         path = data.get("path")

--- a/src/ostorlab/assets/file.py
+++ b/src/ostorlab/assets/file.py
@@ -38,7 +38,7 @@ class File(asset.Asset):
         path = to_str(data.get("path"))
         content_url = to_str(data.get("content_url"))
         content = data.get("content")
-        return cls(path=path, content=content, content_url=content_url)
+        return cls(path=path, content=content, content_url=content_url)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/file.py
+++ b/src/ostorlab/assets/file.py
@@ -1,7 +1,7 @@
 """File asset."""
 
 import dataclasses
-from typing import Optional
+from typing import Optional, Union, cast
 
 from ostorlab.assets import asset
 
@@ -25,20 +25,22 @@ class File(asset.Asset):
         return str_representation
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "File":
-        """Constructs an File asset from a dictionary."""
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "File":
+        """Constructs an AndroidApk asset from a dictionary."""
 
-        def to_str(value: str | bytes | None) -> str | None:
-            if value is None:
-                return None
-            if type(value) is bytes:
-                value = value.decode()
-            return str(value)
-
-        path = to_str(data.get("path"))
-        content_url = to_str(data.get("content_url"))
+        args = {}
+        path = data.get("path")
+        if path is not None:
+            args["path"] = path.decode() if type(path) is bytes else path
+        content_url = data.get("content_url")
+        if content_url is not None:
+            args["content_url"] = (
+                content_url.decode() if type(content_url) is bytes else content_url
+            )
         content = data.get("content")
-        return cls(path=path, content=content, content_url=content_url)  # type: ignore
+        if content is not None:
+            args["content"] = cast(bytes, content)
+        return cls(**args)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/ios_ipa.py
+++ b/src/ostorlab/assets/ios_ipa.py
@@ -38,7 +38,7 @@ class IOSIpa(asset.Asset):
         path = to_str(data.get("path"))
         content_url = to_str(data.get("content_url"))
         content = data.get("content")
-        return cls(path=path, content=content, content_url=content_url)
+        return cls(path=path, content=content, content_url=content_url)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/ios_ipa.py
+++ b/src/ostorlab/assets/ios_ipa.py
@@ -1,7 +1,7 @@
 """iOS .IPA asset."""
 
 import dataclasses
-from typing import Optional
+from typing import Optional, Union, cast
 
 from ostorlab.assets import asset
 
@@ -25,20 +25,22 @@ class IOSIpa(asset.Asset):
         return str_representation
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "IOSIpa":
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "IOSIpa":
         """Constructs an IOSIpa asset from a dictionary."""
 
-        def to_str(value: str | bytes | None) -> str | None:
-            if value is None:
-                return None
-            if type(value) is bytes:
-                value = value.decode()
-            return str(value)
-
-        path = to_str(data.get("path"))
-        content_url = to_str(data.get("content_url"))
+        args = {}
+        path = data.get("path")
+        if path is not None:
+            args["path"] = path.decode() if type(path) is bytes else path
+        content_url = data.get("content_url")
+        if content_url is not None:
+            args["content_url"] = (
+                content_url.decode() if type(content_url) is bytes else content_url
+            )
         content = data.get("content")
-        return cls(path=path, content=content, content_url=content_url)  # type: ignore
+        if content is not None:
+            args["content"] = cast(bytes, content)
+        return cls(**args)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/ios_ipa.py
+++ b/src/ostorlab/assets/ios_ipa.py
@@ -24,6 +24,22 @@ class IOSIpa(asset.Asset):
 
         return str_representation
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "IOSIpa":
+        """Constructs an IOSIpa asset from a dictionary."""
+
+        def to_str(value: str | bytes | None) -> str | None:
+            if value is None:
+                return None
+            if type(value) is bytes:
+                value = value.decode()
+            return str(value)
+
+        path = to_str(data.get("path"))
+        content_url = to_str(data.get("content_url"))
+        content = data.get("content")
+        return cls(path=path, content=content, content_url=content_url)
+
     @property
     def proto_field(self) -> str:
         return "ios_ipa"

--- a/src/ostorlab/assets/ios_store.py
+++ b/src/ostorlab/assets/ios_store.py
@@ -23,7 +23,7 @@ class IOSStore(asset.Asset):
             bundle_id = bundle_id.decode()
         if bundle_id == "":
             raise ValueError("bundle_id is missing.")
-        return IOSStore(bundle_id)
+        return IOSStore(bundle_id)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/ios_store.py
+++ b/src/ostorlab/assets/ios_store.py
@@ -18,7 +18,7 @@ class IOSStore(asset.Asset):
 
     @classmethod
     def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "IOSStore":
-        """Constructs an IOSIpa asset from a dictionary."""
+        """Constructs an IOSStore asset from a dictionary."""
 
         bundle_id = data.get("bundle_id", "")
         if bundle_id == "":

--- a/src/ostorlab/assets/ios_store.py
+++ b/src/ostorlab/assets/ios_store.py
@@ -15,6 +15,16 @@ class IOSStore(asset.Asset):
     def __str__(self) -> str:
         return f"iOS Store ({self.bundle_id})"
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "IOSStore":
+        """Constructs an IOSStore asset from a dictionary."""
+        bundle_id = data.get("bundle_id", "")
+        if type(bundle_id) is bytes:
+            bundle_id = bundle_id.decode()
+        if bundle_id == "":
+            raise ValueError("bundle_id is missing.")
+        return IOSStore(bundle_id)
+
     @property
     def proto_field(self) -> str:
         return "ios_store"

--- a/src/ostorlab/assets/ios_store.py
+++ b/src/ostorlab/assets/ios_store.py
@@ -1,6 +1,7 @@
 """Ios bundle_id target asset"""
 
 import dataclasses
+from typing import Union
 
 from ostorlab.assets import asset
 
@@ -16,14 +17,16 @@ class IOSStore(asset.Asset):
         return f"iOS Store ({self.bundle_id})"
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "IOSStore":
-        """Constructs an IOSStore asset from a dictionary."""
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "IOSStore":
+        """Constructs an IOSIpa asset from a dictionary."""
+
         bundle_id = data.get("bundle_id", "")
-        if type(bundle_id) is bytes:
-            bundle_id = bundle_id.decode()
         if bundle_id == "":
             raise ValueError("bundle_id is missing.")
-        return IOSStore(bundle_id)  # type: ignore
+
+        return cls(
+            bundle_id=bundle_id.decode() if type(bundle_id) is bytes else bundle_id  # type: ignore
+        )
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/ios_testflight.py
+++ b/src/ostorlab/assets/ios_testflight.py
@@ -1,6 +1,7 @@
 """Ios testflight target asset"""
 
 import dataclasses
+from typing import Union, cast
 
 from ostorlab.assets import asset
 
@@ -16,14 +17,20 @@ class IOSTestflight(asset.Asset):
         return f"iOS Testflight ({self.application_url})"
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "IOSTestflight":
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "IOSTestflight":
         """Constructs an IOSTestflight asset from a dictionary."""
+
         application_url = data.get("application_url", "")
-        if type(application_url) is bytes:
-            application_url = application_url.decode()
         if application_url == "":
-            raise ValueError("package_name is missing.")
-        return IOSTestflight(application_url)  # type: ignore
+            raise ValueError("application_url is missing.")
+        return cls(
+            application_url=cast(
+                str,
+                application_url.decode()
+                if type(application_url) is bytes
+                else application_url,
+            )
+        )
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/ios_testflight.py
+++ b/src/ostorlab/assets/ios_testflight.py
@@ -23,7 +23,7 @@ class IOSTestflight(asset.Asset):
             application_url = application_url.decode()
         if application_url == "":
             raise ValueError("package_name is missing.")
-        return IOSTestflight(application_url)
+        return IOSTestflight(application_url)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/ios_testflight.py
+++ b/src/ostorlab/assets/ios_testflight.py
@@ -15,6 +15,16 @@ class IOSTestflight(asset.Asset):
     def __str__(self) -> str:
         return f"iOS Testflight ({self.application_url})"
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "IOSTestflight":
+        """Constructs an IOSTestflight asset from a dictionary."""
+        application_url = data.get("application_url", "")
+        if type(application_url) is bytes:
+            application_url = application_url.decode()
+        if application_url == "":
+            raise ValueError("package_name is missing.")
+        return IOSTestflight(application_url)
+
     @property
     def proto_field(self) -> str:
         return "ios_testflight"

--- a/src/ostorlab/assets/ip.py
+++ b/src/ostorlab/assets/ip.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import ipaddress
-from typing import Optional
+from typing import Optional, Any
 
 from ostorlab.assets import asset
 
@@ -24,9 +24,7 @@ class IP(asset.Asset):
     def from_dict(cls, data: dict[str, str | bytes]) -> "IP":
         """Constructs an IP asset from a dictionary."""
 
-        def to_str(value: str | bytes | None) -> str | None:
-            if value is None:
-                return None
+        def to_str(value: str | bytes) -> str:
             if type(value) is bytes:
                 value = value.decode()
             return str(value)
@@ -34,10 +32,10 @@ class IP(asset.Asset):
         host = to_str(data.get("host", ""))
         if host == "":
             raise ValueError("host is missing.")
-        version = data.get("version")
+        version: Any = data.get("version")
         if version is not None:
             version = int(version)
-        mask = to_str(data.get("mask"))
+        mask = to_str(data.get("mask", ""))
         return cls(host=host, version=version, mask=mask)
 
     def __str__(self) -> str:

--- a/src/ostorlab/assets/ip.py
+++ b/src/ostorlab/assets/ip.py
@@ -20,5 +20,25 @@ class IP(asset.Asset):
         if self.version is None:
             self.version = ipaddress.ip_address(self.host).version
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "IP":
+        """Constructs an IP asset from a dictionary."""
+
+        def to_str(value: str | bytes | None) -> str | None:
+            if value is None:
+                return None
+            if type(value) is bytes:
+                value = value.decode()
+            return str(value)
+
+        host = to_str(data.get("host", ""))
+        if host == "":
+            raise ValueError("host is missing.")
+        version = data.get("version")
+        if version is not None:
+            version = int(version)
+        mask = to_str(data.get("mask"))
+        return cls(host=host, version=version, mask=mask)
+
     def __str__(self) -> str:
         return f"{self.host}/{self.mask}"

--- a/src/ostorlab/assets/ipv4.py
+++ b/src/ostorlab/assets/ipv4.py
@@ -22,9 +22,7 @@ class IPv4(asset.Asset):
     def from_dict(cls, data: dict[str, str | bytes]) -> "IPv4":
         """Constructs an IPv4 asset from a dictionary."""
 
-        def to_str(value: str | bytes | None) -> str | None:
-            if value is None:
-                return None
+        def to_str(value: str | bytes) -> str:
             if type(value) is bytes:
                 value = value.decode()
             return str(value)
@@ -32,7 +30,7 @@ class IPv4(asset.Asset):
         host = to_str(data.get("host", ""))
         if host == "":
             raise ValueError("host is missing.")
-        mask = to_str(data.get("mask"))
+        mask = to_str(data.get("mask", ""))
         return cls(host=host, mask=mask)
 
     @property

--- a/src/ostorlab/assets/ipv4.py
+++ b/src/ostorlab/assets/ipv4.py
@@ -18,6 +18,23 @@ class IPv4(asset.Asset):
     def __str__(self) -> str:
         return f"{self.host}/{self.mask}"
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "IPv4":
+        """Constructs an IPv4 asset from a dictionary."""
+
+        def to_str(value: str | bytes | None) -> str | None:
+            if value is None:
+                return None
+            if type(value) is bytes:
+                value = value.decode()
+            return str(value)
+
+        host = to_str(data.get("host", ""))
+        if host == "":
+            raise ValueError("host is missing.")
+        mask = to_str(data.get("mask"))
+        return cls(host=host, mask=mask)
+
     @property
     def proto_field(self) -> str:
         return "ipv4"

--- a/src/ostorlab/assets/ipv4.py
+++ b/src/ostorlab/assets/ipv4.py
@@ -1,7 +1,7 @@
 """IPv4 address asset."""
 
 import dataclasses
-from typing import Optional
+from typing import Optional, Union
 
 from ostorlab.assets import asset
 
@@ -19,19 +19,17 @@ class IPv4(asset.Asset):
         return f"{self.host}/{self.mask}"
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "IPv4":
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "IPv4":
         """Constructs an IPv4 asset from a dictionary."""
 
-        def to_str(value: str | bytes) -> str:
-            if type(value) is bytes:
-                value = value.decode()
-            return str(value)
-
-        host = to_str(data.get("host", ""))
+        host = data.get("host", "")
         if host == "":
             raise ValueError("host is missing.")
-        mask = to_str(data.get("mask", ""))
-        return cls(host=host, mask=mask)
+        args = {"host": host.decode() if type(host) is bytes else host, "version": 4}
+        mask = data.get("mask")
+        if mask is not None:
+            args["mask"] = mask.decode() if type(mask) is bytes else mask
+        return cls(**args)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/ipv6.py
+++ b/src/ostorlab/assets/ipv6.py
@@ -18,6 +18,23 @@ class IPv6(asset.Asset):
     def __str__(self) -> str:
         return f"{self.host}/{self.mask}"
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "IPv6":
+        """Constructs an IPv6 asset from a dictionary."""
+
+        def to_str(value: str | bytes | None) -> str | None:
+            if value is None:
+                return None
+            if type(value) is bytes:
+                value = value.decode()
+            return str(value)
+
+        host = to_str(data.get("host", ""))
+        if host == "":
+            raise ValueError("host is missing.")
+        mask = to_str(data.get("mask"))
+        return cls(host=host, mask=mask)
+
     @property
     def proto_field(self) -> str:
         return "ipv6"

--- a/src/ostorlab/assets/ipv6.py
+++ b/src/ostorlab/assets/ipv6.py
@@ -1,7 +1,7 @@
 """IPv6 address asset."""
 
 import dataclasses
-from typing import Optional
+from typing import Optional, Union
 
 from ostorlab.assets import asset
 
@@ -19,19 +19,17 @@ class IPv6(asset.Asset):
         return f"{self.host}/{self.mask}"
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "IPv6":
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "IPv6":
         """Constructs an IPv6 asset from a dictionary."""
 
-        def to_str(value: str | bytes) -> str:
-            if type(value) is bytes:
-                value = value.decode()
-            return str(value)
-
-        host = to_str(data.get("host", ""))
+        host = data.get("host", "")
         if host == "":
             raise ValueError("host is missing.")
-        mask = to_str(data.get("mask", ""))
-        return cls(host=host, mask=mask)
+        args = {"host": host.decode() if type(host) is bytes else host, "version": 6}
+        mask = data.get("mask")
+        if mask is not None:
+            args["mask"] = mask.decode() if type(mask) is bytes else mask
+        return cls(**args)  # type: ignore
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/ipv6.py
+++ b/src/ostorlab/assets/ipv6.py
@@ -22,9 +22,7 @@ class IPv6(asset.Asset):
     def from_dict(cls, data: dict[str, str | bytes]) -> "IPv6":
         """Constructs an IPv6 asset from a dictionary."""
 
-        def to_str(value: str | bytes | None) -> str | None:
-            if value is None:
-                return None
+        def to_str(value: str | bytes) -> str:
             if type(value) is bytes:
                 value = value.decode()
             return str(value)
@@ -32,7 +30,7 @@ class IPv6(asset.Asset):
         host = to_str(data.get("host", ""))
         if host == "":
             raise ValueError("host is missing.")
-        mask = to_str(data.get("mask"))
+        mask = to_str(data.get("mask", ""))
         return cls(host=host, mask=mask)
 
     @property

--- a/src/ostorlab/assets/link.py
+++ b/src/ostorlab/assets/link.py
@@ -1,6 +1,7 @@
 """Link asset."""
 
 import dataclasses
+from typing import Union
 
 from ostorlab.assets import asset
 
@@ -17,21 +18,19 @@ class Link(asset.Asset):
         return f"Link {self.url} with method {self.method}"
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | bytes]) -> "Link":
+    def from_dict(cls, data: dict[str, Union[str, bytes]]) -> "Link":
         """Constructs a Link asset from a dictionary."""
 
-        def to_str(value: str | bytes) -> str:
-            if type(value) is bytes:
-                value = value.decode()
-            return str(value)
-
-        url = to_str(data.get("url", ""))
+        url = data.get("url", "")
         if url == "":
             raise ValueError("url is missing.")
-        method = to_str(data.get("method", ""))
+        method = data.get("method", "")
         if method == "":
             raise ValueError("method is missing.")
-        return Link(url=url, method=method)
+        return cls(
+            url=url.decode() if type(url) is bytes else url,  # type: ignore
+            method=method.decode() if type(method) is bytes else method,  # type: ignore
+        )
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/link.py
+++ b/src/ostorlab/assets/link.py
@@ -20,9 +20,7 @@ class Link(asset.Asset):
     def from_dict(cls, data: dict[str, str | bytes]) -> "Link":
         """Constructs a Link asset from a dictionary."""
 
-        def to_str(value: str | bytes | None) -> str | None:
-            if value is None:
-                return None
+        def to_str(value: str | bytes) -> str:
             if type(value) is bytes:
                 value = value.decode()
             return str(value)

--- a/src/ostorlab/assets/link.py
+++ b/src/ostorlab/assets/link.py
@@ -16,6 +16,25 @@ class Link(asset.Asset):
     def __str__(self) -> str:
         return f"Link {self.url} with method {self.method}"
 
+    @classmethod
+    def from_dict(cls, data: dict[str, str | bytes]) -> "Link":
+        """Constructs a Link asset from a dictionary."""
+
+        def to_str(value: str | bytes | None) -> str | None:
+            if value is None:
+                return None
+            if type(value) is bytes:
+                value = value.decode()
+            return str(value)
+
+        url = to_str(data.get("url", ""))
+        if url == "":
+            raise ValueError("url is missing.")
+        method = to_str(data.get("method", ""))
+        if method == "":
+            raise ValueError("method is missing.")
+        return Link(url=url, method=method)
+
     @property
     def proto_field(self) -> str:
         return "link"

--- a/src/ostorlab/runtimes/local/models/models.py
+++ b/src/ostorlab/runtimes/local/models/models.py
@@ -257,7 +257,7 @@ class Vulnerability(Base):
         for metadata_dict in location.get("metadata", []):
             metad_type = metadata_dict.get("type")
             metad_value = metadata_dict.get("value")
-            location_markdwon_value += f"{metad_type.lower()}: {metad_value}  \n"
+            location_markdwon_value += f"{metad_type}: {metad_value}  \n"
         return location_markdwon_value
 
     @staticmethod

--- a/src/ostorlab/runtimes/local/models/models.py
+++ b/src/ostorlab/runtimes/local/models/models.py
@@ -257,7 +257,7 @@ class Vulnerability(Base):
         for metadata_dict in location.get("metadata", []):
             metad_type = metadata_dict.get("type")
             metad_value = metadata_dict.get("value")
-            location_markdwon_value += f"{metad_type}: {metad_value}  \n"
+            location_markdwon_value += f"{metad_type.lower()}: {metad_value}  \n"
         return location_markdwon_value
 
     @staticmethod

--- a/tests/assets/agent_test.py
+++ b/tests/assets/agent_test.py
@@ -1,0 +1,72 @@
+"""Unit tests for Agent asset."""
+
+import pytest
+
+from ostorlab.agent.message import serializer
+from ostorlab.assets import agent
+
+
+def testAgentAssetToProto_whenSelectorIsSetAndCorrect_generatesProto():
+    """Test to_proto method with correct selector."""
+    asset = agent.Agent(key="agent_key", version="1.0.0")
+    raw = asset.to_proto()
+
+    assert isinstance(raw, bytes)
+    unraw = serializer.deserialize("v3.asset.agent", raw)
+    assert unraw.key == "agent_key"
+
+
+def testAgentAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test Agent.from_dict() returns the expected object with string values."""
+    data = {
+        "key": "agent_key",
+        "version": "1.0.0",
+        "docker_location": "docker",
+        "yaml_file_location": "yaml",
+    }
+    expected_agent = agent.Agent(
+        key="agent_key",
+        version="1.0.0",
+        docker_location="docker",
+        yaml_file_location="yaml",
+    )
+
+    agent_asset = agent.Agent.from_dict(data)
+
+    assert agent_asset == expected_agent
+
+
+def testAgentAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test Agent.from_dict() returns the expected object with bytes values."""
+    data = {
+        "key": b"agent_key",
+        "version": b"1.0.0",
+        "docker_location": b"docker",
+        "yaml_file_location": b"yaml",
+    }
+    expected_agent = agent.Agent(
+        key="agent_key",
+        version="1.0.0",
+        docker_location="docker",
+        yaml_file_location="yaml",
+    )
+
+    agent_asset = agent.Agent.from_dict(data)
+
+    assert agent_asset == expected_agent
+
+
+def testAgentAssetFromDict_missingKey_raisesValueError():
+    """Test Agent.from_dict() raises ValueError when key is missing."""
+    with pytest.raises(ValueError, match="key is missing."):
+        agent.Agent.from_dict({})
+
+
+def testAgentAssetFromDict_missingAllOptionalFields_returnsExpectedObject():
+    """Test Agent.from_dict() returns the expected object when all optional fields are not provided."""
+    data = {"key": "agent_key"}
+    expected_agent = agent.Agent(key="agent_key")
+
+    agent_asset = agent.Agent.from_dict(data)
+
+    assert agent_asset == expected_agent

--- a/tests/assets/android_aab_test.py
+++ b/tests/assets/android_aab_test.py
@@ -1,0 +1,19 @@
+"""Unit tests for Android AAB asset."""
+
+from ostorlab.assets import android_aab
+
+
+def testAndroidAabAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test AndroidAab.from_dict() returns the expected object."""
+    data = {"content": b"aab_content", "path": "/path/to/aab"}
+    expected_aab = android_aab.AndroidAab(content=b"aab_content", path="/path/to/aab")
+    aab = android_aab.AndroidAab.from_dict(data)
+    assert aab == expected_aab
+
+
+def testAndroidAabAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test AndroidAab.from_dict() returns the expected object with bytes values."""
+    data = {"content": b"aab_content", "path": b"/path/to/aab"}
+    expected_aab = android_aab.AndroidAab(content=b"aab_content", path="/path/to/aab")
+    aab = android_aab.AndroidAab.from_dict(data)
+    assert aab == expected_aab

--- a/tests/assets/android_aab_test.py
+++ b/tests/assets/android_aab_test.py
@@ -7,7 +7,9 @@ def testAndroidAabAssetFromDict_withStringValues_returnsExpectedObject():
     """Test AndroidAab.from_dict() returns the expected object."""
     data = {"content": b"aab_content", "path": "/path/to/aab"}
     expected_aab = android_aab.AndroidAab(content=b"aab_content", path="/path/to/aab")
+
     aab = android_aab.AndroidAab.from_dict(data)
+
     assert aab == expected_aab
 
 
@@ -15,5 +17,7 @@ def testAndroidAabAssetFromDict_withBytesValues_returnsExpectedObject():
     """Test AndroidAab.from_dict() returns the expected object with bytes values."""
     data = {"content": b"aab_content", "path": b"/path/to/aab"}
     expected_aab = android_aab.AndroidAab(content=b"aab_content", path="/path/to/aab")
+
     aab = android_aab.AndroidAab.from_dict(data)
+
     assert aab == expected_aab

--- a/tests/assets/android_aab_test.py
+++ b/tests/assets/android_aab_test.py
@@ -5,8 +5,16 @@ from ostorlab.assets import android_aab
 
 def testAndroidAabAssetFromDict_withStringValues_returnsExpectedObject():
     """Test AndroidAab.from_dict() returns the expected object."""
-    data = {"content": b"aab_content", "path": "/path/to/aab"}
-    expected_aab = android_aab.AndroidAab(content=b"aab_content", path="/path/to/aab")
+    data = {
+        "content": b"aab_content",
+        "path": "/path/to/aab",
+        "content_url": "https://host.com/app.aab",
+    }
+    expected_aab = android_aab.AndroidAab(
+        content=b"aab_content",
+        path="/path/to/aab",
+        content_url="https://host.com/app.aab",
+    )
 
     aab = android_aab.AndroidAab.from_dict(data)
 

--- a/tests/assets/android_aab_test.py
+++ b/tests/assets/android_aab_test.py
@@ -21,3 +21,13 @@ def testAndroidAabAssetFromDict_withBytesValues_returnsExpectedObject():
     aab = android_aab.AndroidAab.from_dict(data)
 
     assert aab == expected_aab
+
+
+def testAndroidAabAssetFromDict_missingOptionalFields_returnsExpectedObject():
+    """Test AndroidAab.from_dict() returns the expected object when optional fields are not provided."""
+    data = {}
+    expected_aab = android_aab.AndroidAab()
+
+    aab = android_aab.AndroidAab.from_dict(data)
+
+    assert aab == expected_aab

--- a/tests/assets/android_apk_test.py
+++ b/tests/assets/android_apk_test.py
@@ -21,3 +21,13 @@ def testAndroidApkAssetFromDict_withBytesValues_returnsExpectedObject():
     apk = android_apk.AndroidApk.from_dict(data)
 
     assert apk == expected_apk
+
+
+def testAndroidApkAssetFromDict_missingOptionalFields_returnsExpectedObject():
+    """Test AndroidApk.from_dict() returns the expected object when optional fields are not provided."""
+    data = {}
+    expected_aab = android_apk.AndroidApk()
+
+    aab = android_apk.AndroidApk.from_dict(data)
+
+    assert aab == expected_aab

--- a/tests/assets/android_apk_test.py
+++ b/tests/assets/android_apk_test.py
@@ -7,7 +7,9 @@ def testAndroidApkAssetFromDict_withStringValues_returnsExpectedObject():
     """Test AndroidApk.from_dict() returns the expected object with string values."""
     data = {"content": b"apk_content", "path": "/path/to/apk"}
     expected_apk = android_apk.AndroidApk(content=b"apk_content", path="/path/to/apk")
+
     apk = android_apk.AndroidApk.from_dict(data)
+
     assert apk == expected_apk
 
 
@@ -15,5 +17,7 @@ def testAndroidApkAssetFromDict_withBytesValues_returnsExpectedObject():
     """Test AndroidApk.from_dict() returns the expected object with bytes values."""
     data = {"content": b"apk_content", "path": b"/path/to/apk"}
     expected_apk = android_apk.AndroidApk(content=b"apk_content", path="/path/to/apk")
+
     apk = android_apk.AndroidApk.from_dict(data)
+
     assert apk == expected_apk

--- a/tests/assets/android_apk_test.py
+++ b/tests/assets/android_apk_test.py
@@ -1,0 +1,19 @@
+"""Unit tests for Android APK asset."""
+
+from ostorlab.assets import android_apk
+
+
+def testAndroidApkAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test AndroidApk.from_dict() returns the expected object with string values."""
+    data = {"content": b"apk_content", "path": "/path/to/apk"}
+    expected_apk = android_apk.AndroidApk(content=b"apk_content", path="/path/to/apk")
+    apk = android_apk.AndroidApk.from_dict(data)
+    assert apk == expected_apk
+
+
+def testAndroidApkAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test AndroidApk.from_dict() returns the expected object with bytes values."""
+    data = {"content": b"apk_content", "path": b"/path/to/apk"}
+    expected_apk = android_apk.AndroidApk(content=b"apk_content", path="/path/to/apk")
+    apk = android_apk.AndroidApk.from_dict(data)
+    assert apk == expected_apk

--- a/tests/assets/android_store_test.py
+++ b/tests/assets/android_store_test.py
@@ -9,7 +9,9 @@ def testAndroidStoreAssetFromDict_withStringValues_returnsExpectedObject():
     """Test AndroidStore.from_dict() returns the expected object."""
     data = {"package_name": "com.test.app"}
     expected_android_store = android_store.AndroidStore(package_name="com.test.app")
+
     android_store_asset = android_store.AndroidStore.from_dict(data)
+
     assert android_store_asset == expected_android_store
 
 
@@ -17,7 +19,9 @@ def testAndroidStoreAssetFromDict_withBytesValues_returnsExpectedObject():
     """Test AndroidStore.from_dict() returns the expected object with bytes values."""
     data = {"package_name": b"com.test.app"}
     expected_android_store = android_store.AndroidStore(package_name="com.test.app")
+
     android_store_asset = android_store.AndroidStore.from_dict(data)
+
     assert android_store_asset == expected_android_store
 
 

--- a/tests/assets/android_store_test.py
+++ b/tests/assets/android_store_test.py
@@ -1,0 +1,27 @@
+"""Unit tests for Android Store asset."""
+
+import pytest
+
+from ostorlab.assets import android_store
+
+
+def testAndroidStoreAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test AndroidStore.from_dict() returns the expected object."""
+    data = {"package_name": "com.test.app"}
+    expected_android_store = android_store.AndroidStore(package_name="com.test.app")
+    android_store_asset = android_store.AndroidStore.from_dict(data)
+    assert android_store_asset == expected_android_store
+
+
+def testAndroidStoreAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test AndroidStore.from_dict() returns the expected object with bytes values."""
+    data = {"package_name": b"com.test.app"}
+    expected_android_store = android_store.AndroidStore(package_name="com.test.app")
+    android_store_asset = android_store.AndroidStore.from_dict(data)
+    assert android_store_asset == expected_android_store
+
+
+def testAndroidStoreAssetFromDict_missingPackageName_raisesValueError():
+    """Test AndroidStore.from_dict() raises ValueError when package_name is missing."""
+    with pytest.raises(ValueError, match="package_name is missing."):
+        android_store.AndroidStore.from_dict({})

--- a/tests/assets/api_schema_test.py
+++ b/tests/assets/api_schema_test.py
@@ -19,7 +19,9 @@ def testApiSchemaAssetFromDict_withStringValues_returnsExpectedObject():
         content_url="http://example.com/schema",
         schema_type="openapi",
     )
+
     api_schema_asset = api_schema.ApiSchema.from_dict(data)
+
     assert api_schema_asset == expected_api_schema
 
 
@@ -37,7 +39,9 @@ def testApiSchemaAssetFromDict_withBytesValues_returnsExpectedObject():
         content_url="http://example.com/schema",
         schema_type="openapi",
     )
+
     api_schema_asset = api_schema.ApiSchema.from_dict(data)
+
     assert api_schema_asset == expected_api_schema
 
 

--- a/tests/assets/api_schema_test.py
+++ b/tests/assets/api_schema_test.py
@@ -49,3 +49,17 @@ def testApiSchemaAssetFromDict_missingEndpointUrl_raisesValueError():
     """Test ApiSchema.from_dict() raises ValueError when endpoint_url is missing."""
     with pytest.raises(ValueError, match="endpoint_url is missing."):
         api_schema.ApiSchema.from_dict({})
+
+
+def testApiSchemaAssetFromDict_missingOptionals_returnsExpectedObject():
+    """Test ApiSchema.from_dict() returns the expected object with bytes values."""
+    data = {
+        "endpoint_url": b"http://example.com/api",
+    }
+    expected_api_schema = api_schema.ApiSchema(
+        endpoint_url="http://example.com/api",
+    )
+
+    api_schema_asset = api_schema.ApiSchema.from_dict(data)
+
+    assert api_schema_asset == expected_api_schema

--- a/tests/assets/api_schema_test.py
+++ b/tests/assets/api_schema_test.py
@@ -1,0 +1,47 @@
+"""Unit tests for API Schema asset."""
+
+import pytest
+
+from ostorlab.assets import api_schema
+
+
+def testApiSchemaAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test ApiSchema.from_dict() returns the expected object with string values."""
+    data = {
+        "endpoint_url": "http://example.com/api",
+        "content": b"schema_content",
+        "content_url": "http://example.com/schema",
+        "schema_type": "openapi",
+    }
+    expected_api_schema = api_schema.ApiSchema(
+        endpoint_url="http://example.com/api",
+        content=b"schema_content",
+        content_url="http://example.com/schema",
+        schema_type="openapi",
+    )
+    api_schema_asset = api_schema.ApiSchema.from_dict(data)
+    assert api_schema_asset == expected_api_schema
+
+
+def testApiSchemaAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test ApiSchema.from_dict() returns the expected object with bytes values."""
+    data = {
+        "endpoint_url": b"http://example.com/api",
+        "content": b"schema_content",
+        "content_url": b"http://example.com/schema",
+        "schema_type": b"openapi",
+    }
+    expected_api_schema = api_schema.ApiSchema(
+        endpoint_url="http://example.com/api",
+        content=b"schema_content",
+        content_url="http://example.com/schema",
+        schema_type="openapi",
+    )
+    api_schema_asset = api_schema.ApiSchema.from_dict(data)
+    assert api_schema_asset == expected_api_schema
+
+
+def testApiSchemaAssetFromDict_missingEndpointUrl_raisesValueError():
+    """Test ApiSchema.from_dict() raises ValueError when endpoint_url is missing."""
+    with pytest.raises(ValueError, match="endpoint_url is missing."):
+        api_schema.ApiSchema.from_dict({})

--- a/tests/assets/asset_test.py
+++ b/tests/assets/asset_test.py
@@ -20,7 +20,6 @@ from ostorlab.assets import ip as ip_asset
 from ostorlab.assets import ipv4 as ipv4_asset
 from ostorlab.assets import ipv6 as ipv6_asset
 from ostorlab.assets import link as link_asset
-from ostorlab.assets.asset import UnknownSelector
 
 
 def testAssetToProto_whenSelectorIsSetAndCorrect_generatesProto():
@@ -200,7 +199,7 @@ def testAssetFromDictFactory_withUnknownSelector_raisesValueError():
     selector = "unknown.selector"
 
     with pytest.raises(
-        UnknownSelector,
+        asset.UnknownSelector,
         match=f"Could not create asset object due to unknown selector: {selector}",
     ):
         asset.from_dict_factory(selector, {})

--- a/tests/assets/asset_test.py
+++ b/tests/assets/asset_test.py
@@ -2,8 +2,24 @@
 
 import dataclasses
 
+import pytest
+
 from ostorlab.agent.message import serializer
 from ostorlab.assets import asset
+from ostorlab.assets import android_apk
+from ostorlab.assets import android_aab
+from ostorlab.assets import ios_ipa
+from ostorlab.assets import ios_testflight
+from ostorlab.assets import android_store
+from ostorlab.assets import domain_name
+from ostorlab.assets import file as file_asset
+from ostorlab.assets import api_schema
+from ostorlab.assets import agent as agent_asset
+from ostorlab.assets import ios_store
+from ostorlab.assets import ip as ip_asset
+from ostorlab.assets import ipv4 as ipv4_asset
+from ostorlab.assets import ipv6 as ipv6_asset
+from ostorlab.assets import link as link_asset
 
 
 def testAssetToProto_whenSelectorIsSetAndCorrect_generatesProto():
@@ -16,3 +32,145 @@ def testAssetToProto_whenSelectorIsSetAndCorrect_generatesProto():
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.file.android.apk", raw)
     assert unraw.content == b"test"
+
+
+def testAssetFromDictFactory_withAndroidApkSelector_returnsAndroidApkAsset():
+    """Test from_dict_factory returns AndroidApk asset when selector is v3.asset.file.android.apk."""
+    data = {"content": b"apk_content", "path": "/path/to/apk"}
+    apk_asset = asset.from_dict_factory("v3.asset.file.android.apk", data)
+    assert isinstance(apk_asset, android_apk.AndroidApk)
+    assert apk_asset == android_apk.AndroidApk(
+        content=b"apk_content", path="/path/to/apk"
+    )
+
+
+def testAssetFromDictFactory_withAndroidAabSelector_returnsAndroidAabAsset():
+    """Test from_dict_factory returns AndroidAab asset when selector is v3.asset.file.android.aab."""
+    data = {"content": b"aab_content", "path": "/path/to/aab"}
+    aab_asset = asset.from_dict_factory("v3.asset.file.android.aab", data)
+    assert isinstance(aab_asset, android_aab.AndroidAab)
+    assert aab_asset == android_aab.AndroidAab(
+        content=b"aab_content", path="/path/to/aab"
+    )
+
+
+def testAssetFromDictFactory_withIosIpaSelector_returnsIosIpaAsset():
+    """Test from_dict_factory returns IosIpa asset when selector is v3.asset.file.ios.ipa."""
+    data = {"content": b"ipa_content", "path": "/path/to/ipa"}
+    ipa_asset = asset.from_dict_factory("v3.asset.file.ios.ipa", data)
+    assert isinstance(ipa_asset, ios_ipa.IOSIpa)
+    assert ipa_asset == ios_ipa.IOSIpa(content=b"ipa_content", path="/path/to/ipa")
+
+
+def testAssetFromDictFactory_withIosTestflightSelector_returnsIosTestflightAsset():
+    """Test from_dict_factory returns IosTestflight asset when selector is v3.asset.file.ios.testflight."""
+    data = {"application_url": "http://example.com"}
+    ios_testflight_asset = asset.from_dict_factory("v3.asset.file.ios.testflight", data)
+    assert isinstance(ios_testflight_asset, ios_testflight.IOSTestflight)
+    assert ios_testflight_asset == ios_testflight.IOSTestflight(
+        application_url="http://example.com"
+    )
+
+
+def testAssetFromDictFactory_withAndroidStoreSelector_returnsAndroidStoreAsset():
+    """Test from_dict_factory returns AndroidStore asset when selector is v3.asset.store.android_store."""
+    data = {"package_name": "com.test.app"}
+    android_store_asset = asset.from_dict_factory("v3.asset.store.android_store", data)
+    assert isinstance(android_store_asset, android_store.AndroidStore)
+    assert android_store_asset == android_store.AndroidStore(
+        package_name="com.test.app"
+    )
+
+
+def testAssetFromDictFactory_withIosStoreSelector_returnsIosStoreAsset():
+    """Test from_dict_factory returns IosStore asset when selector is v3.asset.store.ios_store."""
+    data = {"bundle_id": "com.test.app"}
+    ios_store_asset = asset.from_dict_factory("v3.asset.store.ios_store", data)
+    assert isinstance(ios_store_asset, ios_store.IOSStore)
+    assert ios_store_asset == ios_store.IOSStore(bundle_id="com.test.app")
+
+
+def testAssetFromDictFactory_withDomainNameSelector_returnsDomainNameAsset():
+    """Test from_dict_factory returns DomainName asset when selector is v3.asset.domain_name."""
+    data = {"name": "ostorlab.co"}
+    domain_name_asset = asset.from_dict_factory("v3.asset.domain_name", data)
+    assert isinstance(domain_name_asset, domain_name.DomainName)
+    assert domain_name_asset == domain_name.DomainName(name="ostorlab.co")
+
+
+def testAssetFromDictFactory_withFileSelector_returnsFileAsset():
+    """Test from_dict_factory returns File asset when selector is v3.asset.file."""
+    data = {"content": b"file_content", "path": "/path/to/file"}
+    file_asset_obj = asset.from_dict_factory("v3.asset.file", data)
+    assert isinstance(file_asset_obj, file_asset.File)
+    assert file_asset_obj == file_asset.File(
+        content=b"file_content", path="/path/to/file"
+    )
+
+
+def testAssetFromDictFactory_withApiSchemaSelector_returnsApiSchemaAsset():
+    """Test from_dict_factory returns ApiSchema asset when selector is v3.asset.file.api_schema."""
+    data = {
+        "endpoint_url": "http://example.com/api",
+        "content": b"schema_content",
+        "content_url": "http://example.com/schema",
+        "schema_type": "openapi",
+    }
+    api_schema_asset_obj = asset.from_dict_factory("v3.asset.file.api_schema", data)
+    assert isinstance(api_schema_asset_obj, api_schema.ApiSchema)
+    assert api_schema_asset_obj == api_schema.ApiSchema(
+        endpoint_url="http://example.com/api",
+        content=b"schema_content",
+        content_url="http://example.com/schema",
+        schema_type="openapi",
+    )
+
+
+def testAssetFromDictFactory_withAgentSelector_returnsAgentAsset():
+    """Test from_dict_factory returns Agent asset when selector is v3.asset.agent."""
+    data = {"key": "agent_key", "version": "1.0.0"}
+    agent_asset_obj = asset.from_dict_factory("v3.asset.agent", data)
+    assert isinstance(agent_asset_obj, agent_asset.Agent)
+    assert agent_asset_obj == agent_asset.Agent(key="agent_key", version="1.0.0")
+
+
+def testAssetFromDictFactory_withIpSelector_returnsIpAsset():
+    """Test from_dict_factory returns IP asset when selector is v3.asset.ip."""
+    data = {"host": "127.0.0.1", "version": "4", "mask": "32"}
+    ip_asset_obj = asset.from_dict_factory("v3.asset.ip", data)
+    assert isinstance(ip_asset_obj, ip_asset.IP)
+    assert ip_asset_obj == ip_asset.IP(host="127.0.0.1", version=4, mask="32")
+
+
+def testAssetFromDictFactory_withIpv4Selector_returnsIpv4Asset():
+    """Test from_dict_factory returns IPv4 asset when selector is v3.asset.ip.v4."""
+    data = {"host": "127.0.0.1", "mask": "32"}
+    ipv4_asset_obj = asset.from_dict_factory("v3.asset.ip.v4", data)
+    assert isinstance(ipv4_asset_obj, ipv4_asset.IPv4)
+    assert ipv4_asset_obj == ipv4_asset.IPv4(host="127.0.0.1", mask="32")
+
+
+def testAssetFromDictFactory_withIpv6Selector_returnsIpv6Asset():
+    """Test from_dict_factory returns IPv6 asset when selector is v3.asset.ip.v6."""
+    data = {"host": "::1", "mask": "128"}
+    ipv6_asset_obj = asset.from_dict_factory("v3.asset.ip.v6", data)
+    assert isinstance(ipv6_asset_obj, ipv6_asset.IPv6)
+    assert ipv6_asset_obj == ipv6_asset.IPv6(host="::1", mask="128")
+
+
+def testAssetFromDictFactory_withLinkSelector_returnsLinkAsset():
+    """Test from_dict_factory returns Link asset when selector is v3.asset.link."""
+    data = {"url": "http://example.com", "method": "GET"}
+    link_asset_obj = asset.from_dict_factory("v3.asset.link", data)
+    assert isinstance(link_asset_obj, link_asset.Link)
+    assert link_asset_obj == link_asset.Link(url="http://example.com", method="GET")
+
+
+def testAssetFromDictFactory_withUnknownSelector_raisesValueError():
+    """Test from_dict_factory raises ValueError when selector is unknown."""
+    selector = "unknown.selector"
+    with pytest.raises(
+        ValueError,
+        match=f"Could not create asset object due to unknown selector: {selector}",
+    ):
+        asset.from_dict_factory(selector, {})

--- a/tests/assets/asset_test.py
+++ b/tests/assets/asset_test.py
@@ -37,7 +37,9 @@ def testAssetToProto_whenSelectorIsSetAndCorrect_generatesProto():
 def testAssetFromDictFactory_withAndroidApkSelector_returnsAndroidApkAsset():
     """Test from_dict_factory returns AndroidApk asset when selector is v3.asset.file.android.apk."""
     data = {"content": b"apk_content", "path": "/path/to/apk"}
+
     apk_asset = asset.from_dict_factory("v3.asset.file.android.apk", data)
+
     assert isinstance(apk_asset, android_apk.AndroidApk)
     assert apk_asset == android_apk.AndroidApk(
         content=b"apk_content", path="/path/to/apk"
@@ -47,7 +49,9 @@ def testAssetFromDictFactory_withAndroidApkSelector_returnsAndroidApkAsset():
 def testAssetFromDictFactory_withAndroidAabSelector_returnsAndroidAabAsset():
     """Test from_dict_factory returns AndroidAab asset when selector is v3.asset.file.android.aab."""
     data = {"content": b"aab_content", "path": "/path/to/aab"}
+
     aab_asset = asset.from_dict_factory("v3.asset.file.android.aab", data)
+
     assert isinstance(aab_asset, android_aab.AndroidAab)
     assert aab_asset == android_aab.AndroidAab(
         content=b"aab_content", path="/path/to/aab"
@@ -57,7 +61,9 @@ def testAssetFromDictFactory_withAndroidAabSelector_returnsAndroidAabAsset():
 def testAssetFromDictFactory_withIosIpaSelector_returnsIosIpaAsset():
     """Test from_dict_factory returns IosIpa asset when selector is v3.asset.file.ios.ipa."""
     data = {"content": b"ipa_content", "path": "/path/to/ipa"}
+
     ipa_asset = asset.from_dict_factory("v3.asset.file.ios.ipa", data)
+
     assert isinstance(ipa_asset, ios_ipa.IOSIpa)
     assert ipa_asset == ios_ipa.IOSIpa(content=b"ipa_content", path="/path/to/ipa")
 
@@ -65,7 +71,9 @@ def testAssetFromDictFactory_withIosIpaSelector_returnsIosIpaAsset():
 def testAssetFromDictFactory_withIosTestflightSelector_returnsIosTestflightAsset():
     """Test from_dict_factory returns IosTestflight asset when selector is v3.asset.file.ios.testflight."""
     data = {"application_url": "http://example.com"}
+
     ios_testflight_asset = asset.from_dict_factory("v3.asset.file.ios.testflight", data)
+
     assert isinstance(ios_testflight_asset, ios_testflight.IOSTestflight)
     assert ios_testflight_asset == ios_testflight.IOSTestflight(
         application_url="http://example.com"
@@ -75,7 +83,9 @@ def testAssetFromDictFactory_withIosTestflightSelector_returnsIosTestflightAsset
 def testAssetFromDictFactory_withAndroidStoreSelector_returnsAndroidStoreAsset():
     """Test from_dict_factory returns AndroidStore asset when selector is v3.asset.store.android_store."""
     data = {"package_name": "com.test.app"}
+
     android_store_asset = asset.from_dict_factory("v3.asset.store.android_store", data)
+
     assert isinstance(android_store_asset, android_store.AndroidStore)
     assert android_store_asset == android_store.AndroidStore(
         package_name="com.test.app"
@@ -85,7 +95,9 @@ def testAssetFromDictFactory_withAndroidStoreSelector_returnsAndroidStoreAsset()
 def testAssetFromDictFactory_withIosStoreSelector_returnsIosStoreAsset():
     """Test from_dict_factory returns IosStore asset when selector is v3.asset.store.ios_store."""
     data = {"bundle_id": "com.test.app"}
+
     ios_store_asset = asset.from_dict_factory("v3.asset.store.ios_store", data)
+
     assert isinstance(ios_store_asset, ios_store.IOSStore)
     assert ios_store_asset == ios_store.IOSStore(bundle_id="com.test.app")
 
@@ -93,7 +105,9 @@ def testAssetFromDictFactory_withIosStoreSelector_returnsIosStoreAsset():
 def testAssetFromDictFactory_withDomainNameSelector_returnsDomainNameAsset():
     """Test from_dict_factory returns DomainName asset when selector is v3.asset.domain_name."""
     data = {"name": "ostorlab.co"}
+
     domain_name_asset = asset.from_dict_factory("v3.asset.domain_name", data)
+
     assert isinstance(domain_name_asset, domain_name.DomainName)
     assert domain_name_asset == domain_name.DomainName(name="ostorlab.co")
 
@@ -101,7 +115,9 @@ def testAssetFromDictFactory_withDomainNameSelector_returnsDomainNameAsset():
 def testAssetFromDictFactory_withFileSelector_returnsFileAsset():
     """Test from_dict_factory returns File asset when selector is v3.asset.file."""
     data = {"content": b"file_content", "path": "/path/to/file"}
+
     file_asset_obj = asset.from_dict_factory("v3.asset.file", data)
+
     assert isinstance(file_asset_obj, file_asset.File)
     assert file_asset_obj == file_asset.File(
         content=b"file_content", path="/path/to/file"
@@ -116,7 +132,9 @@ def testAssetFromDictFactory_withApiSchemaSelector_returnsApiSchemaAsset():
         "content_url": "http://example.com/schema",
         "schema_type": "openapi",
     }
+
     api_schema_asset_obj = asset.from_dict_factory("v3.asset.file.api_schema", data)
+
     assert isinstance(api_schema_asset_obj, api_schema.ApiSchema)
     assert api_schema_asset_obj == api_schema.ApiSchema(
         endpoint_url="http://example.com/api",
@@ -129,7 +147,9 @@ def testAssetFromDictFactory_withApiSchemaSelector_returnsApiSchemaAsset():
 def testAssetFromDictFactory_withAgentSelector_returnsAgentAsset():
     """Test from_dict_factory returns Agent asset when selector is v3.asset.agent."""
     data = {"key": "agent_key", "version": "1.0.0"}
+
     agent_asset_obj = asset.from_dict_factory("v3.asset.agent", data)
+
     assert isinstance(agent_asset_obj, agent_asset.Agent)
     assert agent_asset_obj == agent_asset.Agent(key="agent_key", version="1.0.0")
 
@@ -137,7 +157,9 @@ def testAssetFromDictFactory_withAgentSelector_returnsAgentAsset():
 def testAssetFromDictFactory_withIpSelector_returnsIpAsset():
     """Test from_dict_factory returns IP asset when selector is v3.asset.ip."""
     data = {"host": "127.0.0.1", "version": "4", "mask": "32"}
+
     ip_asset_obj = asset.from_dict_factory("v3.asset.ip", data)
+
     assert isinstance(ip_asset_obj, ip_asset.IP)
     assert ip_asset_obj == ip_asset.IP(host="127.0.0.1", version=4, mask="32")
 
@@ -145,7 +167,9 @@ def testAssetFromDictFactory_withIpSelector_returnsIpAsset():
 def testAssetFromDictFactory_withIpv4Selector_returnsIpv4Asset():
     """Test from_dict_factory returns IPv4 asset when selector is v3.asset.ip.v4."""
     data = {"host": "127.0.0.1", "mask": "32"}
+
     ipv4_asset_obj = asset.from_dict_factory("v3.asset.ip.v4", data)
+
     assert isinstance(ipv4_asset_obj, ipv4_asset.IPv4)
     assert ipv4_asset_obj == ipv4_asset.IPv4(host="127.0.0.1", mask="32")
 
@@ -153,7 +177,9 @@ def testAssetFromDictFactory_withIpv4Selector_returnsIpv4Asset():
 def testAssetFromDictFactory_withIpv6Selector_returnsIpv6Asset():
     """Test from_dict_factory returns IPv6 asset when selector is v3.asset.ip.v6."""
     data = {"host": "::1", "mask": "128"}
+
     ipv6_asset_obj = asset.from_dict_factory("v3.asset.ip.v6", data)
+
     assert isinstance(ipv6_asset_obj, ipv6_asset.IPv6)
     assert ipv6_asset_obj == ipv6_asset.IPv6(host="::1", mask="128")
 
@@ -161,7 +187,9 @@ def testAssetFromDictFactory_withIpv6Selector_returnsIpv6Asset():
 def testAssetFromDictFactory_withLinkSelector_returnsLinkAsset():
     """Test from_dict_factory returns Link asset when selector is v3.asset.link."""
     data = {"url": "http://example.com", "method": "GET"}
+
     link_asset_obj = asset.from_dict_factory("v3.asset.link", data)
+
     assert isinstance(link_asset_obj, link_asset.Link)
     assert link_asset_obj == link_asset.Link(url="http://example.com", method="GET")
 
@@ -169,6 +197,7 @@ def testAssetFromDictFactory_withLinkSelector_returnsLinkAsset():
 def testAssetFromDictFactory_withUnknownSelector_raisesValueError():
     """Test from_dict_factory raises ValueError when selector is unknown."""
     selector = "unknown.selector"
+
     with pytest.raises(
         ValueError,
         match=f"Could not create asset object due to unknown selector: {selector}",

--- a/tests/assets/asset_test.py
+++ b/tests/assets/asset_test.py
@@ -20,6 +20,7 @@ from ostorlab.assets import ip as ip_asset
 from ostorlab.assets import ipv4 as ipv4_asset
 from ostorlab.assets import ipv6 as ipv6_asset
 from ostorlab.assets import link as link_asset
+from ostorlab.assets.asset import UnknownSelector
 
 
 def testAssetToProto_whenSelectorIsSetAndCorrect_generatesProto():
@@ -199,7 +200,7 @@ def testAssetFromDictFactory_withUnknownSelector_raisesValueError():
     selector = "unknown.selector"
 
     with pytest.raises(
-        ValueError,
+        UnknownSelector,
         match=f"Could not create asset object due to unknown selector: {selector}",
     ):
         asset.from_dict_factory(selector, {})

--- a/tests/assets/domain_name_test.py
+++ b/tests/assets/domain_name_test.py
@@ -1,0 +1,19 @@
+"""Unit tests for Domain Name asset."""
+
+import pytest
+
+from ostorlab.assets import domain_name
+
+
+def test_domain_name_asset_from_dict_returns_expected_object():
+    """Test DomainName.from_dict() returns the expected object."""
+    data = {"name": "ostorlab.co"}
+    expected_domain_name = domain_name.DomainName(name="ostorlab.co")
+    domain_name_asset = domain_name.DomainName.from_dict(data)
+    assert domain_name_asset == expected_domain_name
+
+
+def test_domain_name_asset_from_dict_missing_name_raises_value_error():
+    """Test DomainName.from_dict() raises ValueError when name is missing."""
+    with pytest.raises(ValueError, match="name is missing."):
+        domain_name.DomainName.from_dict({})

--- a/tests/assets/domain_name_test.py
+++ b/tests/assets/domain_name_test.py
@@ -5,15 +5,23 @@ import pytest
 from ostorlab.assets import domain_name
 
 
-def test_domain_name_asset_from_dict_returns_expected_object():
-    """Test DomainName.from_dict() returns the expected object."""
+def testDomainNameAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test DomainName.from_dict() returns the expected object with string values."""
     data = {"name": "ostorlab.co"}
     expected_domain_name = domain_name.DomainName(name="ostorlab.co")
     domain_name_asset = domain_name.DomainName.from_dict(data)
     assert domain_name_asset == expected_domain_name
 
 
-def test_domain_name_asset_from_dict_missing_name_raises_value_error():
+def testDomainNameAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test DomainName.from_dict() returns the expected object with bytes values."""
+    data = {"name": b"ostorlab.co"}
+    expected_domain_name = domain_name.DomainName(name="ostorlab.co")
+    domain_name_asset = domain_name.DomainName.from_dict(data)
+    assert domain_name_asset == expected_domain_name
+
+
+def testDomainNameAssetFromDict_missingName_raisesValueError():
     """Test DomainName.from_dict() raises ValueError when name is missing."""
     with pytest.raises(ValueError, match="name is missing."):
         domain_name.DomainName.from_dict({})

--- a/tests/assets/domain_name_test.py
+++ b/tests/assets/domain_name_test.py
@@ -9,7 +9,9 @@ def testDomainNameAssetFromDict_withStringValues_returnsExpectedObject():
     """Test DomainName.from_dict() returns the expected object with string values."""
     data = {"name": "ostorlab.co"}
     expected_domain_name = domain_name.DomainName(name="ostorlab.co")
+
     domain_name_asset = domain_name.DomainName.from_dict(data)
+
     assert domain_name_asset == expected_domain_name
 
 
@@ -17,7 +19,9 @@ def testDomainNameAssetFromDict_withBytesValues_returnsExpectedObject():
     """Test DomainName.from_dict() returns the expected object with bytes values."""
     data = {"name": b"ostorlab.co"}
     expected_domain_name = domain_name.DomainName(name="ostorlab.co")
+
     domain_name_asset = domain_name.DomainName.from_dict(data)
+
     assert domain_name_asset == expected_domain_name
 
 

--- a/tests/assets/file_test.py
+++ b/tests/assets/file_test.py
@@ -4,19 +4,29 @@ from ostorlab.agent.message import serializer
 from ostorlab.assets import file as file_asset
 
 
-def testFileAsset_whenSelectorIsSetAndCorrect_generatesProto():
-    raw = file_asset.File(
-        content=b"test", path="/test", content_url="http://test.com"
-    ).to_proto()
+def testFileAssetToProto_whenSelectorIsSetAndCorrect_generatesProto():
+    raw = file_asset.File(content=b"test").to_proto()
 
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.file", raw)
     assert unraw.content == b"test"
 
 
-def test_file_asset_from_dict_success():
+def testFileAssetFromDict_withStringValues_returnsExpectedObject():
     """Test FileAsset.from_dict creates an object when at least one field is provided."""
     data = {"content": b"test_content", "path": "/test/path"}
+
     file_asset_obj = file_asset.File.from_dict(data)
+
+    assert file_asset_obj.content == b"test_content"
+    assert file_asset_obj.path == "/test/path"
+
+
+def testFileAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test FileAsset.from_dict creates an object when at least one field is provided."""
+    data = {"content": b"test_content", "path": b"/test/path"}
+
+    file_asset_obj = file_asset.File.from_dict(data)
+
     assert file_asset_obj.content == b"test_content"
     assert file_asset_obj.path == "/test/path"

--- a/tests/assets/file_test.py
+++ b/tests/assets/file_test.py
@@ -30,3 +30,13 @@ def testFileAssetFromDict_withBytesValues_returnsExpectedObject():
 
     assert file_asset_obj.content == b"test_content"
     assert file_asset_obj.path == "/test/path"
+
+
+def testAndroidAabAssetFromDict_missingOptionalFields_returnsExpectedObject():
+    """Test AndroidAab.from_dict() returns the expected object when optional fields are not provided."""
+    data = {}
+    expected_aab = file_asset.File()
+
+    aab = file_asset.File.from_dict(data)
+
+    assert aab == expected_aab

--- a/tests/assets/file_test.py
+++ b/tests/assets/file_test.py
@@ -5,8 +5,18 @@ from ostorlab.assets import file as file_asset
 
 
 def testFileAsset_whenSelectorIsSetAndCorrect_generatesProto():
-    raw = file_asset.File(content=b"test").to_proto()
+    raw = file_asset.File(
+        content=b"test", path="/test", content_url="http://test.com"
+    ).to_proto()
 
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.file", raw)
     assert unraw.content == b"test"
+
+
+def test_file_asset_from_dict_success():
+    """Test FileAsset.from_dict creates an object when at least one field is provided."""
+    data = {"content": b"test_content", "path": "/test/path"}
+    file_asset_obj = file_asset.File.from_dict(data)
+    assert file_asset_obj.content == b"test_content"
+    assert file_asset_obj.path == "/test/path"

--- a/tests/assets/ios_ipa_test.py
+++ b/tests/assets/ios_ipa_test.py
@@ -7,7 +7,9 @@ def testIosIpaAssetFromDict_withStringValues_returnsExpectedObject():
     """Test IOSIpa.from_dict() returns the expected object."""
     data = {"content": b"ipa_content", "path": "/path/to/ipa"}
     expected_ios_ipa = ios_ipa.IOSIpa(content=b"ipa_content", path="/path/to/ipa")
+
     ios_ipa_asset = ios_ipa.IOSIpa.from_dict(data)
+
     assert ios_ipa_asset == expected_ios_ipa
 
 
@@ -15,5 +17,7 @@ def testIosIpaAssetFromDict_withBytesValues_returnsExpectedObject():
     """Test IOSIpa.from_dict() returns the expected object with bytes values."""
     data = {"content": b"ipa_content", "path": b"/path/to/ipa"}
     expected_ios_ipa = ios_ipa.IOSIpa(content=b"ipa_content", path="/path/to/ipa")
+
     ios_ipa_asset = ios_ipa.IOSIpa.from_dict(data)
+
     assert ios_ipa_asset == expected_ios_ipa

--- a/tests/assets/ios_ipa_test.py
+++ b/tests/assets/ios_ipa_test.py
@@ -1,0 +1,19 @@
+"""Unit tests for iOS IPA asset."""
+
+from ostorlab.assets import ios_ipa
+
+
+def testIosIpaAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test IOSIpa.from_dict() returns the expected object."""
+    data = {"content": b"ipa_content", "path": "/path/to/ipa"}
+    expected_ios_ipa = ios_ipa.IOSIpa(content=b"ipa_content", path="/path/to/ipa")
+    ios_ipa_asset = ios_ipa.IOSIpa.from_dict(data)
+    assert ios_ipa_asset == expected_ios_ipa
+
+
+def testIosIpaAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test IOSIpa.from_dict() returns the expected object with bytes values."""
+    data = {"content": b"ipa_content", "path": b"/path/to/ipa"}
+    expected_ios_ipa = ios_ipa.IOSIpa(content=b"ipa_content", path="/path/to/ipa")
+    ios_ipa_asset = ios_ipa.IOSIpa.from_dict(data)
+    assert ios_ipa_asset == expected_ios_ipa

--- a/tests/assets/ios_ipa_test.py
+++ b/tests/assets/ios_ipa_test.py
@@ -21,3 +21,13 @@ def testIosIpaAssetFromDict_withBytesValues_returnsExpectedObject():
     ios_ipa_asset = ios_ipa.IOSIpa.from_dict(data)
 
     assert ios_ipa_asset == expected_ios_ipa
+
+
+def testAndroidAabAssetFromDict_missingOptionalFields_returnsExpectedObject():
+    """Test AndroidAab.from_dict() returns the expected object when optional fields are not provided."""
+    data = {}
+    expected_aab = ios_ipa.IOSIpa()
+
+    aab = ios_ipa.IOSIpa.from_dict(data)
+
+    assert aab == expected_aab

--- a/tests/assets/ios_store_test.py
+++ b/tests/assets/ios_store_test.py
@@ -9,7 +9,9 @@ def testIosStoreAssetFromDict_withStringValues_returnsExpectedObject():
     """Test IOSStore.from_dict() returns the expected object with string values."""
     data = {"bundle_id": "com.test.app"}
     expected_ios_store = ios_store.IOSStore(bundle_id="com.test.app")
+
     ios_store_asset = ios_store.IOSStore.from_dict(data)
+
     assert ios_store_asset == expected_ios_store
 
 
@@ -17,7 +19,9 @@ def testIosStoreAssetFromDict_withBytesValues_returnsExpectedObject():
     """Test IOSStore.from_dict() returns the expected object with bytes values."""
     data = {"bundle_id": b"com.test.app"}
     expected_ios_store = ios_store.IOSStore(bundle_id="com.test.app")
+
     ios_store_asset = ios_store.IOSStore.from_dict(data)
+
     assert ios_store_asset == expected_ios_store
 
 

--- a/tests/assets/ios_store_test.py
+++ b/tests/assets/ios_store_test.py
@@ -1,0 +1,27 @@
+"""Unit tests for iOS Store asset."""
+
+import pytest
+
+from ostorlab.assets import ios_store
+
+
+def testIosStoreAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test IOSStore.from_dict() returns the expected object with string values."""
+    data = {"bundle_id": "com.test.app"}
+    expected_ios_store = ios_store.IOSStore(bundle_id="com.test.app")
+    ios_store_asset = ios_store.IOSStore.from_dict(data)
+    assert ios_store_asset == expected_ios_store
+
+
+def testIosStoreAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test IOSStore.from_dict() returns the expected object with bytes values."""
+    data = {"bundle_id": b"com.test.app"}
+    expected_ios_store = ios_store.IOSStore(bundle_id="com.test.app")
+    ios_store_asset = ios_store.IOSStore.from_dict(data)
+    assert ios_store_asset == expected_ios_store
+
+
+def testIosStoreAssetFromDict_missingBundleId_raisesValueError():
+    """Test IOSStore.from_dict() raises ValueError when bundle_id is missing."""
+    with pytest.raises(ValueError, match="bundle_id is missing."):
+        ios_store.IOSStore.from_dict({})

--- a/tests/assets/ios_testflight_test.py
+++ b/tests/assets/ios_testflight_test.py
@@ -31,5 +31,5 @@ def testIosTestflightAssetFromDict_withBytesValues_returnsExpectedObject():
 
 def testIosTestflightAssetFromDict_missingApplicationUrl_raisesValueError():
     """Test IOSTestflight.from_dict() raises ValueError when application_url is missing."""
-    with pytest.raises(ValueError, match="package_name is missing."):
+    with pytest.raises(ValueError, match="application_url is missing."):
         ios_testflight.IOSTestflight.from_dict({})

--- a/tests/assets/ios_testflight_test.py
+++ b/tests/assets/ios_testflight_test.py
@@ -11,7 +11,9 @@ def testIosTestflightAssetFromDict_withStringValues_returnsExpectedObject():
     expected_ios_testflight = ios_testflight.IOSTestflight(
         application_url="http://example.com"
     )
+
     ios_testflight_asset = ios_testflight.IOSTestflight.from_dict(data)
+
     assert ios_testflight_asset == expected_ios_testflight
 
 
@@ -21,7 +23,9 @@ def testIosTestflightAssetFromDict_withBytesValues_returnsExpectedObject():
     expected_ios_testflight = ios_testflight.IOSTestflight(
         application_url="http://example.com"
     )
+
     ios_testflight_asset = ios_testflight.IOSTestflight.from_dict(data)
+
     assert ios_testflight_asset == expected_ios_testflight
 
 

--- a/tests/assets/ios_testflight_test.py
+++ b/tests/assets/ios_testflight_test.py
@@ -1,0 +1,31 @@
+"""Unit tests for iOS Testflight asset."""
+
+import pytest
+
+from ostorlab.assets import ios_testflight
+
+
+def testIosTestflightAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test IOSTestflight.from_dict() returns the expected object with string values."""
+    data = {"application_url": "http://example.com"}
+    expected_ios_testflight = ios_testflight.IOSTestflight(
+        application_url="http://example.com"
+    )
+    ios_testflight_asset = ios_testflight.IOSTestflight.from_dict(data)
+    assert ios_testflight_asset == expected_ios_testflight
+
+
+def testIosTestflightAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test IOSTestflight.from_dict() returns the expected object with bytes values."""
+    data = {"application_url": b"http://example.com"}
+    expected_ios_testflight = ios_testflight.IOSTestflight(
+        application_url="http://example.com"
+    )
+    ios_testflight_asset = ios_testflight.IOSTestflight.from_dict(data)
+    assert ios_testflight_asset == expected_ios_testflight
+
+
+def testIosTestflightAssetFromDict_missingApplicationUrl_raisesValueError():
+    """Test IOSTestflight.from_dict() raises ValueError when application_url is missing."""
+    with pytest.raises(ValueError, match="package_name is missing."):
+        ios_testflight.IOSTestflight.from_dict({})

--- a/tests/assets/ip_test.py
+++ b/tests/assets/ip_test.py
@@ -39,3 +39,13 @@ def testIpAssetFromDict_missingHost_raisesValueError():
     """Test IP.from_dict() raises ValueError when host is missing."""
     with pytest.raises(ValueError, match="host is missing."):
         ip.IP.from_dict({})
+
+
+def testIpAssetFromDict_missingOptionals_returnsExpectedObject():
+    """Test IP.from_dict() returns the expected object with string values when optional values are not missing."""
+    data = {"host": "127.0.0.1"}
+    expected_ip = ip.IP(host="127.0.0.1")
+
+    ip_asset = ip.IP.from_dict(data)
+
+    assert ip_asset == expected_ip

--- a/tests/assets/ip_test.py
+++ b/tests/assets/ip_test.py
@@ -1,5 +1,7 @@
 """Unit tests for IP asset."""
 
+import pytest
+
 from ostorlab.agent.message import serializer
 from ostorlab.assets import ip
 
@@ -11,3 +13,25 @@ def testAssetToProto_whenIP_generatesProto():
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.ip", raw)
     assert unraw.host == "192.168.1.1"
+
+
+def testIpAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test IP.from_dict() returns the expected object with string values."""
+    data = {"host": "127.0.0.1", "version": "4", "mask": "32"}
+    expected_ip = ip.IP(host="127.0.0.1", version=4, mask="32")
+    ip_asset = ip.IP.from_dict(data)
+    assert ip_asset == expected_ip
+
+
+def testIpAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test IP.from_dict() returns the expected object with bytes values."""
+    data = {"host": b"127.0.0.1", "version": b"4", "mask": b"32"}
+    expected_ip = ip.IP(host="127.0.0.1", version=4, mask="32")
+    ip_asset = ip.IP.from_dict(data)
+    assert ip_asset == expected_ip
+
+
+def testIpAssetFromDict_missingHost_raisesValueError():
+    """Test IP.from_dict() raises ValueError when host is missing."""
+    with pytest.raises(ValueError, match="host is missing."):
+        ip.IP.from_dict({})

--- a/tests/assets/ip_test.py
+++ b/tests/assets/ip_test.py
@@ -19,7 +19,9 @@ def testIpAssetFromDict_withStringValues_returnsExpectedObject():
     """Test IP.from_dict() returns the expected object with string values."""
     data = {"host": "127.0.0.1", "version": "4", "mask": "32"}
     expected_ip = ip.IP(host="127.0.0.1", version=4, mask="32")
+
     ip_asset = ip.IP.from_dict(data)
+
     assert ip_asset == expected_ip
 
 
@@ -27,7 +29,9 @@ def testIpAssetFromDict_withBytesValues_returnsExpectedObject():
     """Test IP.from_dict() returns the expected object with bytes values."""
     data = {"host": b"127.0.0.1", "version": b"4", "mask": b"32"}
     expected_ip = ip.IP(host="127.0.0.1", version=4, mask="32")
+
     ip_asset = ip.IP.from_dict(data)
+
     assert ip_asset == expected_ip
 
 

--- a/tests/assets/ipv4_test.py
+++ b/tests/assets/ipv4_test.py
@@ -39,3 +39,13 @@ def testIpv4AssetFromDict_missingHost_raisesValueError():
     """Test IPv4.from_dict() raises ValueError when host is missing."""
     with pytest.raises(ValueError, match="host is missing."):
         ipv4.IPv4.from_dict({})
+
+
+def testIpv4AssetFromDict_missingOptionals_returnsExpectedObject():
+    """Test IPv4.from_dict() returns the expected object with string values."""
+    data = {"host": "127.0.0.1"}
+    expected_ipv4 = ipv4.IPv4(host="127.0.0.1")
+
+    ipv4_asset = ipv4.IPv4.from_dict(data)
+
+    assert ipv4_asset == expected_ipv4

--- a/tests/assets/ipv4_test.py
+++ b/tests/assets/ipv4_test.py
@@ -1,5 +1,7 @@
 """Unit tests for IP asset."""
 
+import pytest
+
 from ostorlab.agent.message import serializer
 from ostorlab.assets import ipv4
 
@@ -11,3 +13,25 @@ def testAssetToProto_whenIPv4_generatesProto():
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.ip.v4", raw)
     assert unraw.host == "192.168.1.1"
+
+
+def testIpv4AssetFromDict_withStringValues_returnsExpectedObject():
+    """Test IPv4.from_dict() returns the expected object with string values."""
+    data = {"host": "127.0.0.1", "mask": "32"}
+    expected_ipv4 = ipv4.IPv4(host="127.0.0.1", mask="32")
+    ipv4_asset = ipv4.IPv4.from_dict(data)
+    assert ipv4_asset == expected_ipv4
+
+
+def testIpv4AssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test IPv4.from_dict() returns the expected object with bytes values."""
+    data = {"host": b"127.0.0.1", "mask": b"32"}
+    expected_ipv4 = ipv4.IPv4(host="127.0.0.1", mask="32")
+    ipv4_asset = ipv4.IPv4.from_dict(data)
+    assert ipv4_asset == expected_ipv4
+
+
+def testIpv4AssetFromDict_missingHost_raisesValueError():
+    """Test IPv4.from_dict() raises ValueError when host is missing."""
+    with pytest.raises(ValueError, match="host is missing."):
+        ipv4.IPv4.from_dict({})

--- a/tests/assets/ipv4_test.py
+++ b/tests/assets/ipv4_test.py
@@ -19,7 +19,9 @@ def testIpv4AssetFromDict_withStringValues_returnsExpectedObject():
     """Test IPv4.from_dict() returns the expected object with string values."""
     data = {"host": "127.0.0.1", "mask": "32"}
     expected_ipv4 = ipv4.IPv4(host="127.0.0.1", mask="32")
+
     ipv4_asset = ipv4.IPv4.from_dict(data)
+
     assert ipv4_asset == expected_ipv4
 
 
@@ -27,7 +29,9 @@ def testIpv4AssetFromDict_withBytesValues_returnsExpectedObject():
     """Test IPv4.from_dict() returns the expected object with bytes values."""
     data = {"host": b"127.0.0.1", "mask": b"32"}
     expected_ipv4 = ipv4.IPv4(host="127.0.0.1", mask="32")
+
     ipv4_asset = ipv4.IPv4.from_dict(data)
+
     assert ipv4_asset == expected_ipv4
 
 

--- a/tests/assets/link_test.py
+++ b/tests/assets/link_test.py
@@ -19,7 +19,9 @@ def testLinkAssetFromDict_withStringValues_returnsExpectedObject():
     """Test Link.from_dict() returns the expected object with string values."""
     data = {"url": "http://example.com", "method": "GET"}
     expected_link = link.Link(url="http://example.com", method="GET")
+
     link_asset = link.Link.from_dict(data)
+
     assert link_asset == expected_link
 
 
@@ -27,7 +29,9 @@ def testLinkAssetFromDict_withBytesValues_returnsExpectedObject():
     """Test Link.from_dict() returns the expected object with bytes values."""
     data = {"url": b"http://example.com", "method": b"GET"}
     expected_link = link.Link(url="http://example.com", method="GET")
+
     link_asset = link.Link.from_dict(data)
+
     assert link_asset == expected_link
 
 

--- a/tests/assets/link_test.py
+++ b/tests/assets/link_test.py
@@ -1,5 +1,7 @@
 """Unit tests for Link asset."""
 
+import pytest
+
 from ostorlab.agent.message import serializer
 from ostorlab.assets import link
 
@@ -11,3 +13,31 @@ def testAssetToProto_whenIP_generatesProto():
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.link", raw)
     assert unraw.url == "https://ostorlab.co"
+
+
+def testLinkAssetFromDict_withStringValues_returnsExpectedObject():
+    """Test Link.from_dict() returns the expected object with string values."""
+    data = {"url": "http://example.com", "method": "GET"}
+    expected_link = link.Link(url="http://example.com", method="GET")
+    link_asset = link.Link.from_dict(data)
+    assert link_asset == expected_link
+
+
+def testLinkAssetFromDict_withBytesValues_returnsExpectedObject():
+    """Test Link.from_dict() returns the expected object with bytes values."""
+    data = {"url": b"http://example.com", "method": b"GET"}
+    expected_link = link.Link(url="http://example.com", method="GET")
+    link_asset = link.Link.from_dict(data)
+    assert link_asset == expected_link
+
+
+def testLinkAssetFromDict_missingUrl_raisesValueError():
+    """Test Link.from_dict() raises ValueError when url is missing."""
+    with pytest.raises(ValueError, match="url is missing."):
+        link.Link.from_dict({"method": "GET"})
+
+
+def testLinkAssetFromDict_missingMethod_raisesValueError():
+    """Test Link.from_dict() raises ValueError when method is missing."""
+    with pytest.raises(ValueError, match="method is missing."):
+        link.Link.from_dict({"url": "http://example.com"})


### PR DESCRIPTION
## This PR adds asset `from_dict` factories to instantiate a `Asset` types.

### Usage Example:

```python
from ostorlab.assets import asset
from ostorlab.assets import android_apk

data = {"content": ..., "path": ...}
asset_obj = asset.from_dict_factory("v3.asset.file.android.apk", data)
assert type(asset_obj) is asset.Asset
assert isinstance(asset_obj, android_apk.AndroidApk)
```

### Implementation:

A `from_dict` class method is added to each `Asset` subclass, allowing instantiation from a dictionary.
This method handles cases where dictionary values are `bytes` and decodes them if necessary.
A main factory method, `ostorlab.assets.asset.from_dict_factory`, matches a given selector and returns an instance of the corresponding type.

### Why:

This functionality enables agents to create typed asset objects from `dict` objects (`dict`s are typical containers for assets `message.data`). It avoids duplication if multiple agents need this functionality, and reduces maintenance overhead should any `Asset` type change/added in the future.

**This functionality will initially be used in `agent_auto_exploit`.**
