### PR TITLE
fix: Remove <v3.8 version condition

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ python_requires = >=3.9
 install_requires =
     click
     docker
-    importlib-metadata; python_version<"3.8"
+    importlib-metadata
     jsonschema>=4.4.0
     protobuf==3.20.1
     httpx


### PR DESCRIPTION
### The PR removes the <=3.8 constraint. since 3.8 is not supported by `oxo`.