### PR TITLE
feature: Add universe id to all services

### DIFF
--- a/src/ostorlab/runtimes/lite_local/agent_runtime.py
+++ b/src/ostorlab/runtimes/lite_local/agent_runtime.py
@@ -353,9 +353,8 @@ class AgentRuntime:
         service_name = (
             agent_definition.service_name
             or self.agent.container_image.split(":")[0].replace(".", "")
-            + "_"
-            + self.runtime_name
         )
+        service_name = service_name + "_" + self.runtime_name
 
         # We apply the random str only if it will not break the max docker service name characters (63)
         if len(service_name) + MAX_RANDOM_NAME_LEN < MAX_SERVICE_NAME_LEN:

--- a/src/ostorlab/runtimes/lite_local/agent_runtime.py
+++ b/src/ostorlab/runtimes/lite_local/agent_runtime.py
@@ -354,7 +354,7 @@ class AgentRuntime:
             agent_definition.service_name
             or self.agent.container_image.split(":")[0].replace(".", "")
         )
-        service_name = service_name + "_" + self.runtime_name
+        service_name = f"{service_name}_{self.runtime_name}"
 
         # We apply the random str only if it will not break the max docker service name characters (63)
         if len(service_name) + MAX_RANDOM_NAME_LEN < MAX_SERVICE_NAME_LEN:

--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -343,7 +343,7 @@ class AgentRuntime:
             agent_definition.service_name
             or self.agent.container_image.split(":")[0].replace(".", "")
         )
-        service_name = service_name + "_" + self.runtime_name
+        service_name = f"{service_name}_{self.runtime_name}"
 
         # We apply the random str only if it will not break the max docker service name characters (63)
         if len(service_name) + MAX_RANDOM_NAME_LEN < MAX_SERVICE_NAME_LEN:

--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -342,9 +342,8 @@ class AgentRuntime:
         service_name = (
             agent_definition.service_name
             or self.agent.container_image.split(":")[0].replace(".", "")
-            + "_"
-            + self.runtime_name
         )
+        service_name = service_name + "_" + self.runtime_name
 
         # We apply the random str only if it will not break the max docker service name characters (63)
         if len(service_name) + MAX_RANDOM_NAME_LEN < MAX_SERVICE_NAME_LEN:


### PR DESCRIPTION
In this PR, I've included the runtime_name (universe ID) for all services, as it was previously added only to the images that lacked the service_name attribute in the agent definition.