### PR TITLE
feature: add scope urls regex

### DIFF
--- a/src/ostorlab/apis/scan_create.py
+++ b/src/ostorlab/apis/scan_create.py
@@ -45,6 +45,7 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         scan_profile: str,
         application: BinaryIO,
         test_credential_ids: Optional[List[int]] = None,
+        scope_urls_regexes: Optional[List[str]] = None,
         sboms: list[io.FileIO] = None,
         scan_source: Optional[ScanSource] = None,
     ):
@@ -53,6 +54,7 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         self._scan_profile = scan_profile
         self._application = application
         self._test_credential_ids = test_credential_ids
+        self._scope_urls_regexes = scope_urls_regexes
         self._sboms = sboms
         self._scan_source = scan_source
 
@@ -102,6 +104,7 @@ mutation MobileScan($title: String!, $assetType: String!, $application: Upload!,
                             "repository": self._scan_source.repository,
                             "prNumber": self._scan_source.pr_number,
                             "branch": self._scan_source.branch,
+                            "scopeUrlsRegexes": self._scope_urls_regexes,
                         }
                         if self._scan_source is not None
                         else None,

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -67,6 +67,7 @@ def run_mobile_scan(
         source = ctx.obj["source"]
         pr_number = ctx.obj["pr_number"]
         branch = ctx.obj["branch"]
+        scope_urls_regexes = ctx.obj["scope_urls_regexes"]
         runner = authenticated_runner.AuthenticatedAPIRunner(
             api_key=ctx.obj.get("api_key")
         )
@@ -91,7 +92,10 @@ def run_mobile_scan(
                     pr_number=pr_number,
                     branch=branch,
                 )
-
+            if scope_urls_regexes is not None and len(scope_urls_regexes) > 0:
+                scope_urls_regexes = list(scope_urls_regexes)
+            else:
+                scope_urls_regexes = None
             scan_id = _create_scan(
                 title,
                 scan_profile,
@@ -101,6 +105,7 @@ def run_mobile_scan(
                 runner,
                 sboms,
                 scan_source,
+                scope_urls_regexes,
             )
 
             ci_logger.output(name="scan_id", value=scan_id)
@@ -131,6 +136,7 @@ def _create_scan(
     runner: authenticated_runner.AuthenticatedAPIRunner,
     sboms: List[io.FileIO],
     scan_source: Optional[scan_create_api.ScanSource] = None,
+    scope_urls_regexes: Optional[List[str]] = None,
 ) -> int:
     scan_result = runner.execute(
         scan_create_api.CreateMobileScanAPIRequest(
@@ -141,6 +147,7 @@ def _create_scan(
             test_credential_ids=credential_ids,
             sboms=sboms,
             scan_source=scan_source,
+            scope_urls_regexes=scope_urls_regexes,
         )
     )
     scan_id = scan_result.get("data").get("createMobileScan").get("scan").get("id")

--- a/src/ostorlab/cli/ci_scan/run/run.py
+++ b/src/ostorlab/cli/ci_scan/run/run.py
@@ -114,6 +114,13 @@ CI_LOGGER = {
     default=None,
 )
 @click.option(
+    "--scope-urls-regexes",
+    help="List of URLs regexes.",
+    required=False,
+    multiple=True,
+    default=None,
+)
+@click.option(
     "--proxy",
     "proxy",
     help="Proxy to use if defined.",
@@ -168,6 +175,7 @@ def run(
     sboms: List[io.FileIO],
     api_schema: io.FileIO,
     filtered_url_regexes: List[str],
+    scope_urls_regexes: List[str],
     proxy: str,
     qps: int,
     source: Optional[str] = None,
@@ -221,6 +229,7 @@ def run(
     ctx.obj["sboms"] = sboms
     ctx.obj["api_schema"] = api_schema
     ctx.obj["filtered_url_regexes"] = filtered_url_regexes
+    ctx.obj["scope_urls_regexes"] = scope_urls_regexes
     ctx.obj["proxy"] = proxy
     ctx.obj["qps"] = qps
     ctx.obj["source"] = source


### PR DESCRIPTION
This PR adds  `--scope-urls-regexes` parameter in the CI scan functionality.
The `--scope-urls-regexes` parameter passes URL regex patterns to the API request.