### PR TITLE
fix: Revert "feature: Add link extra args."

### DIFF
--- a/src/ostorlab/assets/link.py
+++ b/src/ostorlab/assets/link.py
@@ -1,7 +1,6 @@
 """Link asset."""
 
 import dataclasses
-from typing import List, Optional, Dict
 
 from ostorlab.assets import asset
 
@@ -9,26 +8,13 @@ from ostorlab.assets import asset
 @dataclasses.dataclass
 @asset.selector("v3.asset.link")
 class Link(asset.Asset):
-    """Link asset."""
+    """Agent asset."""
 
     url: str
     method: str
-    body: Optional[bytes] = None
-    # Headers and Cookies are dict with the keys `name` and `value`.
-    extra_headers: Optional[List[Dict[str, str]]] = dataclasses.field(
-        default_factory=list
-    )
-    cookies: Optional[List[Dict[str, str]]] = dataclasses.field(default_factory=list)
 
     def __str__(self) -> str:
-        info = f"Link {self.url} with method {self.method}"
-        if self.extra_headers is not None and len(self.extra_headers) > 0:
-            info += f", headers: {self.extra_headers}"
-        if self.cookies is not None and len(self.cookies) > 0:
-            info += f", cookies: {self.cookies}"
-        if self.body is not None:
-            info += f", body: {self.body!r}"
-        return info
+        return f"Link {self.url} with method {self.method}"
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/cli/scan/run/assets/link.py
+++ b/src/ostorlab/cli/scan/run/assets/link.py
@@ -1,7 +1,7 @@
 """Asset of type Link."""
 
 import logging
-from typing import List, Optional, Dict
+from typing import List
 
 import click
 
@@ -14,75 +14,32 @@ logger = logging.getLogger(__name__)
 console = cli_console.Console()
 
 
-def _parse_key_value_arg(value: str) -> Dict[str, str]:
-    """Parse a key-value pair, separated by '=' or ':'."""
-    if "=" in value:
-        key, val = value.split("=", 1)
-        return {"name": key.strip(), "value": val.strip()}
-    if ":" in value:
-        key, val = value.split(":", 1)
-        return {"name": key.strip(), "value": val.strip()}
-    raise click.BadParameter(
-        f'Invalid format for "{value}". Use key=value or key:value.'
-    )
-
-
 @run.run.command()
-@click.option("--url", help="URL to scan.", required=True)
-@click.option("--method", help="HTTP method.", required=True)
-@click.option("--body", help="Request body.", required=False)
-@click.option(
-    "--header",
-    "headers",
-    help="Request header. Can be specified multiple times. Format is 'key:value' or 'key=value'.",
-    required=False,
-    multiple=True,
-)
-@click.option(
-    "--cookie",
-    "cookies",
-    help="Request cookie. Can be specified multiple times. Format is 'key:value' or 'key=value'.",
-    required=False,
-    multiple=True,
-)
+@click.option("--url", help="List of Urls to scan.", required=True, multiple=True)
+@click.option("--method", help="List of HTTP methods.", required=True, multiple=True)
 @click.pass_context
-def link(
-    ctx: click.core.Context,
-    url: str,
-    method: str,
-    body: Optional[str],
-    headers: List[str],
-    cookies: List[str],
-) -> None:
-    """Run scan for a link."""
+def link(ctx: click.core.Context, url: List[str], method: List[str]) -> None:
+    """Run scan for links."""
     runtime = ctx.obj["runtime"]
-    try:
-        parsed_headers = [_parse_key_value_arg(h) for h in headers]
-        parsed_cookies = [_parse_key_value_arg(c) for c in cookies]
-    except click.BadParameter as e:
-        console.error(e.message)
-        raise click.exceptions.Exit(2) from e
-
-    body = body.encode() if body is not None else None
-    asset = link_asset.Link(
-        url=url,
-        method=method,
-        body=body,
-        extra_headers=parsed_headers,
-        cookies=parsed_cookies,
-    )
-    logger.debug("scanning asset %s", asset)
+    if len(url) != len(method):
+        console.error("Make sure every URL has its corresponding method.")
+        raise click.exceptions.Exit(2)
+    assets = []
+    for u, m in zip(url, method):
+        asset = link_asset.Link(url=u, method=m)
+        assets.append(asset)
+    logger.debug("scanning assets %s", asset)
     try:
         created_scan = runtime.scan(
             title=ctx.obj["title"],
             agent_group_definition=ctx.obj["agent_group_definition"],
-            assets=[asset],
+            assets=assets,
         )
         if created_scan is not None:
             runtime.link_agent_group_scan(
                 created_scan, ctx.obj["agent_group_definition"]
             )
-            runtime.link_assets_scan(created_scan.id, [asset])
+            runtime.link_assets_scan(created_scan.id, assets)
 
     except exceptions.OstorlabError as e:
         console.error(f"An error was encountered while running the scan: {e}")

--- a/tests/assets/link_test.py
+++ b/tests/assets/link_test.py
@@ -4,45 +4,10 @@ from ostorlab.agent.message import serializer
 from ostorlab.assets import link
 
 
-def testAssetToProto_whenLinkAsset_generatesProto() -> None:
-    """Test that to_proto generates a valid protobuf message for a simple link."""
+def testAssetToProto_whenIP_generatesProto():
     asset = link.Link(url="https://ostorlab.co", method="GET")
     raw = asset.to_proto()
 
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.link", raw)
     assert unraw.url == "https://ostorlab.co"
-    assert unraw.method == "GET"
-    assert not unraw.HasField("body")
-    assert len(unraw.extra_headers) == 0
-    assert len(unraw.cookies) == 0
-
-
-def testAssetToProto_whenLinkAssetWithAllFields_generatesProtoCorrectly() -> None:
-    """Test that to_proto generates a valid protobuf message with all fields."""
-    asset = link.Link(
-        url="https://example.com",
-        method="POST",
-        body=b'{"key": "value"}',
-        extra_headers=[
-            {"name": "Content-Type", "value": "application/json"},
-            {"name": "X-Test", "value": "Test"},
-        ],
-        cookies=[{"name": "session", "value": "12345"}],
-    )
-
-    raw = asset.to_proto()
-
-    assert isinstance(raw, bytes)
-    unraw = serializer.deserialize("v3.asset.link", raw)
-    assert unraw.url == "https://example.com"
-    assert unraw.method == "POST"
-    assert unraw.body == b'{"key": "value"}'
-    assert len(unraw.extra_headers) == 2
-    assert unraw.extra_headers[0].name == "Content-Type"
-    assert unraw.extra_headers[0].value == "application/json"
-    assert unraw.extra_headers[1].name == "X-Test"
-    assert unraw.extra_headers[1].value == "Test"
-    assert len(unraw.cookies) == 1
-    assert unraw.cookies[0].name == "session"
-    assert unraw.cookies[0].value == "12345"

--- a/tests/cli/scan/run/assets/link_test.py
+++ b/tests/cli/scan/run/assets/link_test.py
@@ -48,38 +48,3 @@ def testRunScanLink_whenValidAgentsAreProvidedWithNoAsset_ShowSpecifySubCommandE
     assert "Usage:" not in result.output
     assert isinstance(result.exception, SystemExit)
     assert result.exit_code == 1
-
-
-def testRunScanLink_withHeaderAndCookie_ShowSpecifySubCommandError(
-    mocker,
-) -> None:
-    """Test oxo scan run link with non-supported runtime, should exit with return code 1."""
-
-    mocker.patch(
-        "ostorlab.runtimes.local.runtime.LocalRuntime.can_run", return_value=False
-    )
-    runner = CliRunner()
-    mocker.patch("ostorlab.runtimes.local.LocalRuntime.__init__", return_value=None)
-    result = runner.invoke(
-        rootcli.rootcli,
-        [
-            "scan",
-            "--runtime=local",
-            "run",
-            "--agent=agent1 --agent=agent2",
-            "link",
-            "--url",
-            "https://ostorlab.co",
-            "--method",
-            "GET",
-            "--cookie",
-            "cookie1=123--cookie",
-            "cookie2=456",
-            "--header",
-            "header1=123",
-        ],
-    )
-
-    assert "Usage:" not in result.output
-    assert isinstance(result.exception, SystemExit)
-    assert result.exit_code == 1

--- a/tests/serve_app/oxo_test.py
+++ b/tests/serve_app/oxo_test.py
@@ -3462,7 +3462,6 @@ def testOxoExportScan_alaways_shouldExportScan(
 def testImportScanMutation_whenScanHasMultipleAssets_shouldImportScanWithMultipleAssets(
     authenticated_flask_client: testing.FlaskClient,
     multiple_assets_scan_bytes: bytes,
-    android_store_scan: models.Scan,
     mocker: plugin.MockerFixture,
     db_engine_path: str,
 ) -> None:
@@ -3486,7 +3485,7 @@ def testImportScanMutation_whenScanHasMultipleAssets_shouldImportScanWithMultipl
                     "query": query,
                     "variables": {
                         "file": None,
-                        "scanId": android_store_scan.id,
+                        "scanId": 20,
                     },
                 }
             ),

--- a/tests/serve_app/oxo_test.py
+++ b/tests/serve_app/oxo_test.py
@@ -3462,6 +3462,7 @@ def testOxoExportScan_alaways_shouldExportScan(
 def testImportScanMutation_whenScanHasMultipleAssets_shouldImportScanWithMultipleAssets(
     authenticated_flask_client: testing.FlaskClient,
     multiple_assets_scan_bytes: bytes,
+    android_store_scan: models.Scan,
     mocker: plugin.MockerFixture,
     db_engine_path: str,
 ) -> None:
@@ -3485,7 +3486,7 @@ def testImportScanMutation_whenScanHasMultipleAssets_shouldImportScanWithMultipl
                     "query": query,
                     "variables": {
                         "file": None,
-                        "scanId": 20,
+                        "scanId": android_store_scan.id,
                     },
                 }
             ),


### PR DESCRIPTION
Reverts Ostorlab/oxo#912 since it breaks the logic to pass multiple links to scan in one command.