### PR TITLE
feature: Add support tracker init_sleep argument to be controlled by the cli.

### DIFF
--- a/src/ostorlab/cli/scan/run/run.py
+++ b/src/ostorlab/cli/scan/run/run.py
@@ -96,6 +96,12 @@ WAIT_BETWEEN_RETRIES = 5
     help="Timeout for the scan in seconds",
     required=False,
 )
+@click.option(
+    "--init-sleep",
+    type=int,
+    help="Init sleep for tracker before checking the queues",
+    required=False,
+)
 @click.pass_context
 def run(
     ctx: click.core.Context,
@@ -109,6 +115,7 @@ def run(
     no_follow: bool,
     no_asset: bool,
     timeout: Optional[int] = None,
+    init_sleep: Optional[int] = None,
 ) -> None:
     """Start a new scan on your assets.\n
     Example:\n
@@ -156,6 +163,9 @@ def run(
     runtime_instance: runtime.Runtime = ctx.obj["runtime"]
     if timeout is not None:
         runtime_instance.timeout = timeout
+
+    if init_sleep is not None:
+        runtime_instance.init_sleep = init_sleep
 
     # Prepare and set the list of agents to follow.
     agent_keys = [agent.key for agent in agent_group.agents]

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -200,7 +200,6 @@ class LocalRuntime(runtime.Runtime):
             title: Scan title
             agent_group_definition: Agent run definition defines the set of agents and how agents are configured.
             assets: the target asset to scan.
-            timeout: The timeout in seconds for the tracker agent to wait for all agents to finish.
 
         Returns:
             The scan object.
@@ -524,12 +523,19 @@ class LocalRuntime(runtime.Runtime):
         tracker_agent_settings = definitions.AgentSettings(
             key=TRACKER_AGENT_DEFAULT,
         )
-
         if self.timeout is not None:
             tracker_agent_settings.args.extend(
                 [
                     utils_definitions.Arg(
                         name="scan_done_timeout_sec", type="number", value=self.timeout
+                    ),
+                ]
+            )
+        if self.init_sleep is not None:
+            tracker_agent_settings.args.extend(
+                [
+                    utils_definitions.Arg(
+                        name="init_sleep_seconds", type="number", value=self.init_sleep
                     ),
                 ]
             )

--- a/src/ostorlab/runtimes/runtime.py
+++ b/src/ostorlab/runtimes/runtime.py
@@ -25,6 +25,7 @@ class Runtime(abc.ABC):
 
     follow: list
     timeout: Optional[int] = None
+    init_sleep: Optional[int] = None
 
     @abc.abstractmethod
     def can_run(self, agent_group_definition: definitions.AgentGroupDefinition) -> bool:

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -564,8 +564,7 @@ def testScanRunCLI_whenTimeoutProvided_setsTrackerAgentTimeout(
             "--install",
             "--agent=agent/ostorlab/nmap",
             "--timeout=3600",
-            "--init-sleep=1800"
-            "ip",
+            "--init-sleep=1800ip",
             "8.8.8.8",
         ],
     )
@@ -578,8 +577,7 @@ def testScanRunCLI_whenTimeoutProvided_setsTrackerAgentTimeout(
     )
     assert mock_start_agent.call_args[1].get("agent").args[0].value == 3600
     assert (
-            mock_start_agent.call_args[1].get("agent").args[1].name
-            == "init_sleep_seconds"
+        mock_start_agent.call_args[1].get("agent").args[1].name == "init_sleep_seconds"
     )
     assert mock_start_agent.call_args[1].get("agent").args[0].value == 1800
 

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -564,7 +564,8 @@ def testScanRunCLI_whenTimeoutProvided_setsTrackerAgentTimeout(
             "--install",
             "--agent=agent/ostorlab/nmap",
             "--timeout=3600",
-            "--init-sleep=1800ip",
+            "--init-sleep=1800",
+            "ip",
             "8.8.8.8",
         ],
     )
@@ -579,7 +580,7 @@ def testScanRunCLI_whenTimeoutProvided_setsTrackerAgentTimeout(
     assert (
         mock_start_agent.call_args[1].get("agent").args[1].name == "init_sleep_seconds"
     )
-    assert mock_start_agent.call_args[1].get("agent").args[0].value == 1800
+    assert mock_start_agent.call_args[1].get("agent").args[1].value == 1800
 
 
 def testScanRunCLI_whenNoTimeoutProvided_usesDefaultTimeout(

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -564,6 +564,7 @@ def testScanRunCLI_whenTimeoutProvided_setsTrackerAgentTimeout(
             "--install",
             "--agent=agent/ostorlab/nmap",
             "--timeout=3600",
+            "--init-sleep=1800"
             "ip",
             "8.8.8.8",
         ],
@@ -576,6 +577,11 @@ def testScanRunCLI_whenTimeoutProvided_setsTrackerAgentTimeout(
         == "scan_done_timeout_sec"
     )
     assert mock_start_agent.call_args[1].get("agent").args[0].value == 3600
+    assert (
+            mock_start_agent.call_args[1].get("agent").args[1].name
+            == "init_sleep_seconds"
+    )
+    assert mock_start_agent.call_args[1].get("agent").args[0].value == 1800
 
 
 def testScanRunCLI_whenNoTimeoutProvided_usesDefaultTimeout(


### PR DESCRIPTION
Add support tracker init_sleep argument to be controlled by the CLI.

This is needed when the universe needs to wait for a long warmup before the messages get emitted.