### PR TITLE
feature: Add support for ui automation rules in ostorlab CI/CD pipeline

### DIFF
--- a/src/ostorlab/apis/request.py
+++ b/src/ostorlab/apis/request.py
@@ -27,3 +27,8 @@ class APIRequest(abc.ABC):
     def files(self) -> Optional[Dict]:
         """Files of the API request, containing the binary data."""
         return None
+
+    @property
+    def is_json(self) -> bool:
+        """Indicates if the request should be sent as JSON (default False)."""
+        return False

--- a/src/ostorlab/apis/runners/authenticated_runner.py
+++ b/src/ostorlab/apis/runners/authenticated_runner.py
@@ -163,14 +163,24 @@ class AuthenticatedAPIRunner(runner.APIRunner):
     def _sent_request(
         self, request: api_request.APIRequest, headers: Optional[Dict[str, str]] = None
     ) -> httpx.Response:
-        """Sends an API request."""
+        """Sends an API request, handling JSON or form encoding."""
+        if headers is None:
+            headers = {}
+
+        if request.is_json is True:
+            headers["Content-Type"] = "application/json"
+            data_arg = {"json": request.data}
+        else:
+            # form-encoded
+            data_arg = {"data": request.data}
+
         with httpx.Client(proxy=self._proxy, verify=self._verify) as client:
             return client.post(
                 self.endpoint,
-                data=request.data,
                 files=request.files,
                 headers=headers,
                 timeout=runner.REQUEST_TIMEOUT,
+                **data_arg,
             )
 
     def execute_ubjson_request(self, request: api_request.APIRequest) -> Dict[str, Any]:

--- a/src/ostorlab/apis/runners/authenticated_runner.py
+++ b/src/ostorlab/apis/runners/authenticated_runner.py
@@ -164,24 +164,26 @@ class AuthenticatedAPIRunner(runner.APIRunner):
         self, request: api_request.APIRequest, headers: Optional[Dict[str, str]] = None
     ) -> httpx.Response:
         """Sends an API request, handling JSON or form encoding."""
-        if headers is None:
-            headers = {}
-
-        if request.is_json is True:
-            headers["Content-Type"] = "application/json"
-            data_arg = {"json": request.data}
-        else:
-            # form-encoded
-            data_arg = {"data": request.data}
+        headers = headers or {}
 
         with httpx.Client(proxy=self._proxy, verify=self._verify) as client:
-            return client.post(
-                self.endpoint,
-                files=request.files,
-                headers=headers,
-                timeout=runner.REQUEST_TIMEOUT,
-                **data_arg,
-            )
+            if request.is_json is True:
+                headers["Content-Type"] = "application/json"
+                return client.post(
+                    self.endpoint,
+                    files=request.files,
+                    headers=headers,
+                    timeout=runner.REQUEST_TIMEOUT,
+                    json=request.data,
+                )
+            else:
+                return client.post(
+                    self.endpoint,
+                    files=request.files,
+                    headers=headers,
+                    timeout=runner.REQUEST_TIMEOUT,
+                    data=request.data,
+                )
 
     def execute_ubjson_request(self, request: api_request.APIRequest) -> Dict[str, Any]:
         """Executes a request using the Authenticated GraphQL API.

--- a/src/ostorlab/apis/scan_create.py
+++ b/src/ostorlab/apis/scan_create.py
@@ -16,7 +16,7 @@ class CreateUIPromptsAPIRequest(request.APIRequest):
         self._ui_prompts = ui_prompts
 
     @property
-    def query(self) -> Optional[str]:
+    def query(self) -> str:
         """Defines the query to create UI prompts.
 
         Returns:
@@ -34,7 +34,7 @@ mutation CreateUIPrompts($uiPrompts: [UIAutomationRulesInputType]!) {
         """
 
     @property
-    def data(self) -> Optional[Dict]:
+    def data(self) -> Dict[str, Any]:
         """Sets the query and variables to create UI prompts.
 
         Returns:
@@ -42,19 +42,17 @@ mutation CreateUIPrompts($uiPrompts: [UIAutomationRulesInputType]!) {
         """
         return {
             "query": self.query,
-            "variables": {
-                "uiPrompts": self._ui_prompts,
-            },
+            "variables": json.dumps({"uiPrompts": self._ui_prompts}),
         }
 
     @property
-    def files(self) -> Optional[Dict]:
-        """No files needed for UI prompts creation.
+    def is_json(self) -> bool:
+        """Indicates that the request should be sent as JSON.
 
         Returns:
-            None
+            True if the request should be sent as JSON.
         """
-        return None
+        return True
 
 
 @dataclasses.dataclass

--- a/src/ostorlab/apis/scan_create.py
+++ b/src/ostorlab/apis/scan_create.py
@@ -4,7 +4,7 @@ import enum
 import io
 import json
 import dataclasses
-from typing import Dict, Optional, BinaryIO, List
+from typing import Dict, Optional, BinaryIO, List, Any
 
 from . import request
 
@@ -48,7 +48,7 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         scope_urls_regexes: Optional[List[str]] = None,
         sboms: list[io.FileIO] = None,
         scan_source: Optional[ScanSource] = None,
-        ui_automation_rule_instances: Optional[List[Dict]] = None,
+        ui_automation_rule_instances: Optional[List[Dict[str, Any]]] = None,
     ):
         self._title = title
         self._asset_type = asset_type
@@ -145,7 +145,7 @@ class CreateWebScanAPIRequest(request.APIRequest):
         qps: Optional[int] = None,
         filtered_url_regexes: Optional[List[str]] = None,
         test_credential_ids: Optional[List[int]] = None,
-        ui_automation_rule_instances: Optional[List[Dict]] = None,
+        ui_automation_rule_instances: Optional[List[Dict[str, Any]]] = None,
     ):
         self._title = title
         self._urls = urls

--- a/src/ostorlab/apis/scan_create.py
+++ b/src/ostorlab/apis/scan_create.py
@@ -48,6 +48,7 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         scope_urls_regexes: Optional[List[str]] = None,
         sboms: list[io.FileIO] = None,
         scan_source: Optional[ScanSource] = None,
+        ui_automation_rule_instances: Optional[List[Dict]] = None,
     ):
         self._title = title
         self._asset_type = asset_type
@@ -57,6 +58,7 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         self._scope_urls_regexes = scope_urls_regexes
         self._sboms = sboms
         self._scan_source = scan_source
+        self._ui_automation_rule_instances = ui_automation_rule_instances
 
     @property
     def query(self) -> Optional[str]:
@@ -67,8 +69,8 @@ class CreateMobileScanAPIRequest(request.APIRequest):
         """
 
         return """
-mutation MobileScan($title: String!, $assetType: String!, $application: Upload!, $sboms: [Upload!], $scanProfile: String!, $credentialIds: [Int], $scanSource: ScanSourceInputType, $scopeUrlsRegexes: [String]) {
-  createMobileScan(title: $title, assetType: $assetType, application: $application, sboms: $sboms, scanProfile: $scanProfile, credentialIds: $credentialIds, scanSource: $scanSource, scopeUrlsRegexes: $scopeUrlsRegexes) {
+mutation MobileScan($title: String!, $assetType: String!, $application: Upload!, $sboms: [Upload!], $scanProfile: String!, $credentialIds: [Int], $scanSource: ScanSourceInputType, $scopeUrlsRegexes: [String], $uiAutomationRuleInstances: [UIAutomationRuleInstanceInputType]) {
+  createMobileScan(title: $title, assetType: $assetType, application: $application, sboms: $sboms, scanProfile: $scanProfile, credentialIds: $credentialIds, scanSource: $scanSource, scopeUrlsRegexes: $scopeUrlsRegexes, uiAutomationRuleInstances: $uiAutomationRuleInstances) {
     scan {
       id
     }
@@ -108,6 +110,7 @@ mutation MobileScan($title: String!, $assetType: String!, $application: Upload!,
                         if self._scan_source is not None
                         else None,
                         "scopeUrlsRegexes": self._scope_urls_regexes,
+                        "uiAutomationRuleInstances": self._ui_automation_rule_instances,
                     },
                 }
             ),
@@ -134,14 +137,15 @@ class CreateWebScanAPIRequest(request.APIRequest):
     def __init__(
         self,
         title: str,
-        urls: [List[str]],
+        urls: List[str],
         scan_profile: str,
         sboms: Optional[list[io.FileIO]] = None,
         api_schema: Optional[io.FileIO] = None,
         proxy: Optional[str] = None,
         qps: Optional[int] = None,
-        filtered_url_regexes: [List[str]] = None,
-        test_credential_ids: List[int] = None,
+        filtered_url_regexes: Optional[List[str]] = None,
+        test_credential_ids: Optional[List[int]] = None,
+        ui_automation_rule_instances: Optional[List[Dict]] = None,
     ):
         self._title = title
         self._urls = urls
@@ -152,6 +156,7 @@ class CreateWebScanAPIRequest(request.APIRequest):
         self._qps = qps
         self._filtered_url_regexes = filtered_url_regexes
         self._test_credential_ids = test_credential_ids
+        self._ui_automation_rule_instances = ui_automation_rule_instances
 
     @property
     def query(self) -> Optional[str]:
@@ -162,8 +167,8 @@ class CreateWebScanAPIRequest(request.APIRequest):
         """
 
         return """
-mutation WebScan($title: String!, $urls: [String]!, $scanProfile: String!, $sboms: [Upload!], $apiSchema: Upload, $proxy: String, $qps: Int, $filteredUrlRegexes: [String], $credentialIds: [Int]) {
-  createWebScan(title: $title, urls: $urls, scanProfile: $scanProfile, sboms: $sboms, apiSchema: $apiSchema, proxy: $proxy, qps: $qps, filteredUrlRegexes: $filteredUrlRegexes, credentialIds: $credentialIds) {
+mutation WebScan($title: String!, $urls: [String]!, $scanProfile: String!, $sboms: [Upload!], $apiSchema: Upload, $proxy: String, $qps: Int, $filteredUrlRegexes: [String], $credentialIds: [Int], $uiAutomationRuleInstances: [UIAutomationRuleInstanceInputType]) {
+  createWebScan(title: $title, urls: $urls, scanProfile: $scanProfile, sboms: $sboms, apiSchema: $apiSchema, proxy: $proxy, qps: $qps, filteredUrlRegexes: $filteredUrlRegexes, credentialIds: $credentialIds, uiAutomationRuleInstances: $uiAutomationRuleInstances) {
     scan {
       id
     }
@@ -201,6 +206,7 @@ mutation WebScan($title: String!, $urls: [String]!, $scanProfile: String!, $sbom
                             "proxy": self._proxy,
                             "qps": self._qps,
                             "sboms": [None for _ in self._sboms],
+                            "uiAutomationRuleInstances": self._ui_automation_rule_instances,
                         },
                     }
                 ),
@@ -220,6 +226,7 @@ mutation WebScan($title: String!, $urls: [String]!, $scanProfile: String!, $sbom
                         "proxy": self._proxy,
                         "qps": self._qps,
                         "sboms": [None for _ in self._sboms],
+                        "uiAutomationRuleInstances": self._ui_automation_rule_instances,
                     }
                 ),
             }

--- a/src/ostorlab/cli/ci_scan/run/assets/link.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/link.py
@@ -2,6 +2,8 @@
 This module takes care of preparing a link before calling the create web scan API.
 """
 
+import json
+
 import click
 import itertools
 
@@ -80,16 +82,13 @@ def run_link_scan(ctx: click.core.Context, url: List[str]) -> None:
                 f"creating Web scan `{title}` with profile `{scan_profile}`."
             )
 
-            # Parse UI automation rules from JSON string
             ui_automation_rule_instances = None
             if ui_automation_rules is not None:
                 try:
-                    import json
-
                     ui_automation_rule_instances = json.loads(ui_automation_rules)
                 except (json.JSONDecodeError, TypeError):
-                    ci_logger.error("Invalid UI automation rules format, ignoring.")
-                    ui_automation_rule_instances = None
+                    error_message = f"Invalid UI automation rules format: {ui_automation_rules}, ignoring..."
+                    ci_logger.error(error_message)
 
             scan_id = _create_scan(
                 title,

--- a/src/ostorlab/cli/ci_scan/run/assets/link.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/link.py
@@ -2,12 +2,13 @@
 This module takes care of preparing a link before calling the create web scan API.
 """
 
+import io
 import json
 
 import click
 import itertools
 
-from typing import List
+from typing import List, Optional, Dict, Any
 
 from ostorlab.cli.ci_scan.run import run
 from ostorlab.apis import scan_create as scan_create_api
@@ -124,17 +125,18 @@ def run_link_scan(ctx: click.core.Context, url: List[str]) -> None:
 
 
 def _create_scan(
-    title,
-    scan_profile,
-    urls,
-    credential_ids,
-    runner,
-    sboms,
-    api_schema,
-    filtered_url_regexes,
-    proxy,
-    qps,
-    ui_automation_rule_instances=None,
+    credential_ids: List[int],
+    runner: authenticated_runner.AuthenticatedAPIRunner,
+    title: str,
+    urls: List[str],
+    scan_profile: str,
+    sboms: Optional[list[io.FileIO]] = None,
+    api_schema: Optional[io.FileIO] = None,
+    proxy: Optional[str] = None,
+    qps: Optional[int] = None,
+    filtered_url_regexes: Optional[List[str]] = None,
+    test_credential_ids: Optional[List[int]] = None,
+    ui_automation_rule_instances: Optional[List[Dict[str, Any]]] = None,
 ):
     scan_result = runner.execute(
         scan_create_api.CreateWebScanAPIRequest(

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -107,7 +107,7 @@ def run_mobile_scan(
                 try:
                     ui_automation_rule_instances = json.loads(ui_automation_rules)
                 except (json.JSONDecodeError, TypeError):
-                    ci_logger.error("Invalid UI automation rules format, ignoring.")
+                    ci_logger.error("Invalid UI automation rules format %s, ignoring...", ui_automation_rules)
                     ui_automation_rule_instances = None
 
             scan_id = _create_scan(

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -10,6 +10,8 @@ import itertools
 
 from typing import List, Optional, Dict
 
+from mypy.literals import Any
+
 from ostorlab.cli.ci_scan.run import run
 from ostorlab.apis.runners import authenticated_runner
 from ostorlab.apis.runners import runner as base_runner
@@ -150,7 +152,7 @@ def _create_scan(
     sboms: List[io.FileIO],
     scan_source: Optional[scan_create_api.ScanSource] = None,
     scope_urls_regexes: Optional[List[str]] = None,
-    ui_automation_rule_instances: Optional[List[Dict]] = None,
+    ui_automation_rule_instances: Optional[List[Dict[str, Any]]] = None,
 ) -> int:
     scan_result = runner.execute(
         scan_create_api.CreateMobileScanAPIRequest(

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -106,7 +106,8 @@ def run_mobile_scan(
                 try:
                     ui_automation_rule_instances = json.loads(ui_automation_rules)
                 except (json.JSONDecodeError, TypeError):
-                    ci_logger.error("Invalid UI automation rules format %s, ignoring...", ui_automation_rules)
+                    error_message = f"Invalid UI automation rules format: {ui_automation_rules}, ignoring..."
+                    ci_logger.error(error_message)
                     ui_automation_rule_instances = None
 
             scan_id = _create_scan(

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -3,6 +3,8 @@ This module takes care of preparing the application file and calling the create 
 """
 
 import io
+import json
+
 import click
 import itertools
 
@@ -101,9 +103,8 @@ def run_mobile_scan(
             # Parse UI automation rules from JSON string
             ui_automation_rule_instances = None
             if ui_automation_rules is not None:
+                ci_logger.info(ui_automation_rules)
                 try:
-                    import json
-
                     ui_automation_rule_instances = json.loads(ui_automation_rules)
                 except (json.JSONDecodeError, TypeError):
                     ci_logger.error("Invalid UI automation rules format, ignoring.")

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -3,14 +3,11 @@ This module takes care of preparing the application file and calling the create 
 """
 
 import io
+import itertools
 import json
+from typing import List, Optional
 
 import click
-import itertools
-
-from typing import List, Optional, Dict
-
-from mypy.literals import Any
 
 from ostorlab.cli.ci_scan.run import run
 from ostorlab.apis.runners import authenticated_runner
@@ -72,7 +69,7 @@ def run_mobile_scan(
         pr_number = ctx.obj["pr_number"]
         branch = ctx.obj["branch"]
         scope_urls_regexes = ctx.obj["scope_urls_regexes"]
-        ui_automation_rules = ctx.obj.get("ui_automation_rules")
+        ui_prompts = ctx.obj.get("ui_prompts") or []
         runner = authenticated_runner.AuthenticatedAPIRunner(
             api_key=ctx.obj.get("api_key")
         )
@@ -85,6 +82,30 @@ def run_mobile_scan(
                 )
             else:
                 credential_ids = []
+
+            ui_automation_rule_ids = []
+            if len(ui_prompts) > 0:
+                ui_prompts_json = [{"code": prompt} for prompt in ui_prompts]
+                try:
+                    ci_logger.info("Creating UI prompts...")
+                    prompts_result = runner.execute(
+                        scan_create_api.CreateUIPromptsAPIRequest(
+                            ui_prompts=ui_prompts_json
+                        )
+                    )
+                    ui_automation_rule_ids = [
+                        prompt["id"]
+                        for prompt in prompts_result["data"]["createUiPrompts"][
+                            "uiPrompts"
+                        ]
+                    ]
+                    ci_logger.info(
+                        f"Created UI prompts with IDs: {ui_automation_rule_ids}"
+                    )
+                except (json.JSONDecodeError, KeyError) as e:
+                    ci_logger.error(
+                        f"Invalid UI prompts format: {e}. Continuing without UI prompts."
+                    )
 
             ci_logger.info(
                 f"creating scan `{title}` with profile `{scan_profile}` for `{asset_type}`"
@@ -102,25 +123,17 @@ def run_mobile_scan(
             else:
                 scope_urls_regexes = None
 
-            ui_automation_rule_instances = None
-            if ui_automation_rules is not None:
-                try:
-                    ui_automation_rule_instances = json.loads(ui_automation_rules)
-                except (json.JSONDecodeError, TypeError):
-                    error_message = f"Invalid UI automation rules format: {ui_automation_rules}, ignoring..."
-                    ci_logger.error(error_message)
-
             scan_id = _create_scan(
-                title,
-                scan_profile,
-                asset_type,
-                file,
-                credential_ids,
-                runner,
-                sboms,
-                scan_source,
-                scope_urls_regexes,
-                ui_automation_rule_instances,
+                title=title,
+                scan_profile=scan_profile,
+                asset_type=asset_type,
+                file=file,
+                credential_ids=credential_ids,
+                runner=runner,
+                sboms=sboms,
+                scan_source=scan_source,
+                scope_urls_regexes=scope_urls_regexes,
+                ui_automation_rule_ids=ui_automation_rule_ids,
             )
 
             ci_logger.output(name="scan_id", value=scan_id)
@@ -152,7 +165,7 @@ def _create_scan(
     sboms: List[io.FileIO],
     scan_source: Optional[scan_create_api.ScanSource] = None,
     scope_urls_regexes: Optional[List[str]] = None,
-    ui_automation_rule_instances: Optional[List[Dict[str, Any]]] = None,
+    ui_automation_rule_ids: List[int] = (),
 ) -> int:
     scan_result = runner.execute(
         scan_create_api.CreateMobileScanAPIRequest(
@@ -164,7 +177,7 @@ def _create_scan(
             sboms=sboms,
             scan_source=scan_source,
             scope_urls_regexes=scope_urls_regexes,
-            ui_automation_rule_instances=ui_automation_rule_instances,
+            ui_automation_rule_ids=ui_automation_rule_ids,
         )
     )
     scan_id = scan_result.get("data").get("createMobileScan").get("scan").get("id")

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -103,7 +103,6 @@ def run_mobile_scan(
             # Parse UI automation rules from JSON string
             ui_automation_rule_instances = None
             if ui_automation_rules is not None:
-                ci_logger.info(ui_automation_rules)
                 try:
                     ui_automation_rule_instances = json.loads(ui_automation_rules)
                 except (json.JSONDecodeError, TypeError):

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -100,7 +100,6 @@ def run_mobile_scan(
             else:
                 scope_urls_regexes = None
 
-            # Parse UI automation rules from JSON string
             ui_automation_rule_instances = None
             if ui_automation_rules is not None:
                 try:
@@ -108,7 +107,6 @@ def run_mobile_scan(
                 except (json.JSONDecodeError, TypeError):
                     error_message = f"Invalid UI automation rules format: {ui_automation_rules}, ignoring..."
                     ci_logger.error(error_message)
-                    ui_automation_rule_instances = None
 
             scan_id = _create_scan(
                 title,

--- a/src/ostorlab/cli/ci_scan/run/run.py
+++ b/src/ostorlab/cli/ci_scan/run/run.py
@@ -159,7 +159,8 @@ CI_LOGGER = {
     default=None,
 )
 @click.option(
-    "--ui-prompts",
+    "--ui-prompt",
+    "ui_prompts",
     help="UI prompts to use during the scan.",
     required=False,
     multiple=True,

--- a/src/ostorlab/cli/ci_scan/run/run.py
+++ b/src/ostorlab/cli/ci_scan/run/run.py
@@ -159,10 +159,11 @@ CI_LOGGER = {
     default=None,
 )
 @click.option(
-    "--ui-automation-rules",
-    help="JSON string containing UI automation rules for enhanced web app scanning.",
+    "--ui-prompts",
+    help="UI prompts to use during the scan.",
     required=False,
-    default=None,
+    multiple=True,
+    default=[],
 )
 @click.pass_context
 def run(
@@ -184,11 +185,11 @@ def run(
     scope_urls_regexes: List[str],
     proxy: str,
     qps: int,
+    ui_prompts: List[str],
     source: Optional[str] = None,
     repository: Optional[str] = None,
     pr_number: Optional[str] = None,
     branch: Optional[str] = None,
-    ui_automation_rules: Optional[str] = None,
 ) -> None:
     """Start a scan based on a scan profile in the CI.\n"""
 
@@ -243,7 +244,7 @@ def run(
     ctx.obj["repository"] = repository
     ctx.obj["pr_number"] = pr_number
     ctx.obj["branch"] = branch
-    ctx.obj["ui_automation_rules"] = ui_automation_rules
+    ctx.obj["ui_prompts"] = ui_prompts
 
 
 def apply_break_scan_risk_rating(

--- a/src/ostorlab/cli/ci_scan/run/run.py
+++ b/src/ostorlab/cli/ci_scan/run/run.py
@@ -158,6 +158,12 @@ CI_LOGGER = {
     required=False,
     default=None,
 )
+@click.option(
+    "--ui-automation-rules",
+    help="JSON string containing UI automation rules for enhanced web app scanning.",
+    required=False,
+    default=None,
+)
 @click.pass_context
 def run(
     ctx: click.core.Context,
@@ -182,6 +188,7 @@ def run(
     repository: Optional[str] = None,
     pr_number: Optional[str] = None,
     branch: Optional[str] = None,
+    ui_automation_rules: Optional[str] = None,
 ) -> None:
     """Start a scan based on a scan profile in the CI.\n"""
 
@@ -236,6 +243,7 @@ def run(
     ctx.obj["repository"] = repository
     ctx.obj["pr_number"] = pr_number
     ctx.obj["branch"] = branch
+    ctx.obj["ui_automation_rules"] = ui_automation_rules
 
 
 def apply_break_scan_risk_rating(

--- a/tests/apis/scan_create_test.py
+++ b/tests/apis/scan_create_test.py
@@ -7,11 +7,54 @@ from unittest import mock
 from ostorlab.apis import scan_create
 
 
-def testCreateMobileScanAPIRequest_whenUIAutomationRulesProvided_includesUIAutomationRulesInVariables():
-    """Test CreateMobileScanAPIRequest includes UI automation rules in GraphQL variables."""
-    ui_automation_rules = [
-        {"rule_id": 1, "args": [{"name": "username", "value": "testuser"}]}
+def testCreateUIPromptsAPIRequest_whenUIPromptsProvided_createsCorrectQuery() -> None:
+    """Test CreateUIPromptsAPIRequest creates correct GraphQL query."""
+    ui_prompts = [
+        {"code": "Ensure full coverage of the app"},
+        {"code": "Ensure login works"},
     ]
+
+    api_request = scan_create.CreateUIPromptsAPIRequest(ui_prompts=ui_prompts)
+
+    query = api_request.query
+    assert "mutation CreateUIPrompts" in query
+    assert "$uiPrompts: [UIAutomationRulesInputType]!" in query
+    assert "createUiPrompts(uiPrompts: $uiPrompts)" in query
+    assert "id" in query and "code" in query
+
+
+def testCreateUIPromptsAPIRequest_whenUIPromptsProvided_includesUIPromptsInVariables() -> (
+    None
+):
+    """Test CreateUIPromptsAPIRequest includes UI prompts in GraphQL variables."""
+    ui_prompts = [
+        {"code": "Ensure full coverage of the app"},
+        {"code": "Ensure login works"},
+    ]
+
+    api_request = scan_create.CreateUIPromptsAPIRequest(ui_prompts=ui_prompts)
+
+    data = api_request.data
+    assert "query" in data
+    assert "variables" in data
+    assert data["variables"]["uiPrompts"] == ui_prompts
+
+
+def testCreateUIPromptsAPIRequest_whenCalled_returnsNoFiles() -> None:
+    """Test CreateUIPromptsAPIRequest returns no files."""
+    ui_prompts = [{"code": "Ensure full coverage of the app"}]
+
+    api_request = scan_create.CreateUIPromptsAPIRequest(ui_prompts=ui_prompts)
+
+    files = api_request.files
+    assert files is None
+
+
+def testCreateMobileScanAPIRequest_whenUIAutomationRuleIdsProvided_includesUIAutomationRuleInstancesInVariables() -> (
+    None
+):
+    """Test CreateMobileScanAPIRequest includes UI automation rule instances in GraphQL variables."""
+    ui_automation_rule_ids = [1, 2]
 
     file_mock = mock.Mock(spec=io.FileIO)
     api_request = scan_create.CreateMobileScanAPIRequest(
@@ -20,18 +63,24 @@ def testCreateMobileScanAPIRequest_whenUIAutomationRulesProvided_includesUIAutom
         scan_profile="Full Scan",
         application=file_mock,
         sboms=[],
-        ui_automation_rule_instances=ui_automation_rules,
+        ui_automation_rule_ids=ui_automation_rule_ids,
     )
 
     data = api_request.data
     operations = json.loads(data["operations"])
     variables = operations["variables"]
     assert "uiAutomationRuleInstances" in variables
-    assert variables["uiAutomationRuleInstances"] == ui_automation_rules
+    expected_ui_automation_rules = [
+        {"ruleId": 1, "args": [{"name": "Rule 1"}]},
+        {"ruleId": 2, "args": [{"name": "Rule 2"}]},
+    ]
+    assert variables["uiAutomationRuleInstances"] == expected_ui_automation_rules
 
 
-def testCreateMobileScanAPIRequest_whenUIAutomationRulesNotProvided_setsNullInVariables():
-    """Test CreateMobileScanAPIRequest sets null for UI automation rules when not provided."""
+def testCreateMobileScanAPIRequest_whenUIAutomationRuleIdsNotProvided_setsEmptyListInVariables() -> (
+    None
+):
+    """Test CreateMobileScanAPIRequest sets empty list for UI automation rules when not provided."""
     file_mock = mock.Mock(spec=io.FileIO)
     api_request = scan_create.CreateMobileScanAPIRequest(
         title="Test Scan",
@@ -45,31 +94,37 @@ def testCreateMobileScanAPIRequest_whenUIAutomationRulesNotProvided_setsNullInVa
     operations = json.loads(data["operations"])
     variables = operations["variables"]
     assert "uiAutomationRuleInstances" in variables
-    assert variables["uiAutomationRuleInstances"] is None
+    assert variables["uiAutomationRuleInstances"] == []
 
 
-def testCreateWebScanAPIRequest_whenUIAutomationRulesProvided_includesUIAutomationRulesInVariables():
-    """Test CreateWebScanAPIRequest includes UI automation rules in GraphQL variables."""
-    ui_automation_rules = [
-        {"rule_id": 2, "args": [{"name": "password", "value": "testpass"}]}
+def testCreateWebScanAPIRequest_whenUIAutomationRuleIdsProvided_includesUIAutomationRuleInstancesInVariables() -> (
+    None
+):
+    """Test CreateWebScanAPIRequest includes UI automation rule instances in GraphQL variables."""
+    ui_automation_rule_ids = [3, 4]
+
+    api_request = scan_create.CreateWebScanAPIRequest(
+        title="Test Web Scan",
+        urls=["https://example.com"],
+        scan_profile="Full Scan",
+        sboms=[],
+        ui_automation_rule_ids=ui_automation_rule_ids,
+    )
+
+    data = api_request.data
+    variables = json.loads(data["variables"])
+    assert "uiAutomationRuleInstances" in variables
+    expected_ui_automation_rules = [
+        {"ruleId": 3, "args": [{"name": "Rule 3"}]},
+        {"ruleId": 4, "args": [{"name": "Rule 4"}]},
     ]
-
-    api_request = scan_create.CreateWebScanAPIRequest(
-        title="Test Web Scan",
-        urls=["https://example.com"],
-        scan_profile="Full Scan",
-        sboms=[],
-        ui_automation_rule_instances=ui_automation_rules,
-    )
-
-    data = api_request.data
-    variables = json.loads(data["variables"])
-    assert "uiAutomationRuleInstances" in variables
-    assert variables["uiAutomationRuleInstances"] == ui_automation_rules
+    assert variables["uiAutomationRuleInstances"] == expected_ui_automation_rules
 
 
-def testCreateWebScanAPIRequest_whenUIAutomationRulesNotProvided_setsNullInVariables():
-    """Test CreateWebScanAPIRequest sets null for UI automation rules when not provided."""
+def testCreateWebScanAPIRequest_whenUIAutomationRuleIdsNotProvided_setsEmptyListInVariables() -> (
+    None
+):
+    """Test CreateWebScanAPIRequest sets empty list for UI automation rules when not provided."""
     api_request = scan_create.CreateWebScanAPIRequest(
         title="Test Web Scan",
         urls=["https://example.com"],
@@ -80,11 +135,11 @@ def testCreateWebScanAPIRequest_whenUIAutomationRulesNotProvided_setsNullInVaria
     data = api_request.data
     variables = json.loads(data["variables"])
     assert "uiAutomationRuleInstances" in variables
-    assert variables["uiAutomationRuleInstances"] is None
+    assert variables["uiAutomationRuleInstances"] == []
 
 
-def testCreateMobileScanAPIRequest_UIAutomationRulesInQuery():
-    """Test CreateMobileScanAPIRequest includes UI automation rules in GraphQL query."""
+def testCreateMobileScanAPIRequest_UIAutomationRuleInstancesInQuery() -> None:
+    """Test CreateMobileScanAPIRequest includes UI automation rule instances in GraphQL query."""
     file_mock = mock.Mock(spec=io.FileIO)
     api_request = scan_create.CreateMobileScanAPIRequest(
         title="Test Scan",
@@ -92,22 +147,107 @@ def testCreateMobileScanAPIRequest_UIAutomationRulesInQuery():
         scan_profile="Full Scan",
         application=file_mock,
         sboms=[],
-        ui_automation_rule_instances=[],
+        ui_automation_rule_ids=[],
     )
 
     query = api_request.query
+    assert "uiAutomationRuleInstances: [UIAutomationRuleInstanceInputType]" in query
     assert "uiAutomationRuleInstances: $uiAutomationRuleInstances" in query
 
 
-def testCreateWebScanAPIRequest_UIAutomationRulesInQuery():
-    """Test CreateWebScanAPIRequest includes UI automation rules in GraphQL query."""
+def testCreateWebScanAPIRequest_UIAutomationRuleInstancesInQuery() -> None:
+    """Test CreateWebScanAPIRequest includes UI automation rule instances in GraphQL query."""
     api_request = scan_create.CreateWebScanAPIRequest(
         title="Test Web Scan",
         urls=["https://example.com"],
         scan_profile="Full Scan",
         sboms=[],
-        ui_automation_rule_instances=[],
+        ui_automation_rule_ids=[],
     )
 
     query = api_request.query
+    assert "uiAutomationRuleInstances: [UIAutomationRuleInstanceInputType]" in query
     assert "uiAutomationRuleInstances: $uiAutomationRuleInstances" in query
+
+
+def testCreateMobileScanAPIRequest_withMultipleUIAutomationRuleIds_createsCorrectStructure() -> (
+    None
+):
+    """Test CreateMobileScanAPIRequest with multiple UI automation rule IDs creates correct structure."""
+    ui_automation_rule_ids = [10, 20, 30]
+
+    file_mock = mock.Mock(spec=io.FileIO)
+    api_request = scan_create.CreateMobileScanAPIRequest(
+        title="Test Scan",
+        asset_type=scan_create.MobileAssetType.IOS,
+        scan_profile="Full Scan",
+        application=file_mock,
+        sboms=[],
+        ui_automation_rule_ids=ui_automation_rule_ids,
+    )
+
+    data = api_request.data
+    operations = json.loads(data["operations"])
+    variables = operations["variables"]
+
+    expected_ui_automation_rules = [
+        {"ruleId": 10, "args": [{"name": "Rule 10"}]},
+        {"ruleId": 20, "args": [{"name": "Rule 20"}]},
+        {"ruleId": 30, "args": [{"name": "Rule 30"}]},
+    ]
+    assert variables["uiAutomationRuleInstances"] == expected_ui_automation_rules
+    assert variables["assetType"] == "ios"
+    assert variables["title"] == "Test Scan"
+
+
+def testCreateWebScanAPIRequest_withFilesAndUIAutomationRuleIds_usesOperationsFormat() -> (
+    None
+):
+    """Test CreateWebScanAPIRequest with files and UI automation rule IDs uses operations format."""
+    ui_automation_rule_ids = [5]
+    sbom_mock = mock.Mock(spec=io.FileIO)
+
+    api_request = scan_create.CreateWebScanAPIRequest(
+        title="Test Web Scan",
+        urls=["https://example.com", "https://test.com"],
+        scan_profile="Full Web Scan",
+        sboms=[sbom_mock],
+        ui_automation_rule_ids=ui_automation_rule_ids,
+    )
+
+    data = api_request.data
+    assert "operations" in data
+    assert "map" in data
+
+    operations = json.loads(data["operations"])
+    variables = operations["variables"]
+    assert variables["uiAutomationRuleInstances"] == [
+        {"ruleId": 5, "args": [{"name": "Rule 5"}]}
+    ]
+    assert variables["urls"] == ["https://example.com", "https://test.com"]
+
+
+def testCreateWebScanAPIRequest_withNoFilesButUIAutomationRuleIds_usesSimpleFormat() -> (
+    None
+):
+    """Test CreateWebScanAPIRequest with no files but UI automation rule IDs uses simple format."""
+    ui_automation_rule_ids = [7]
+
+    api_request = scan_create.CreateWebScanAPIRequest(
+        title="Test Web Scan",
+        urls=["https://example.com"],
+        scan_profile="Full Web Scan",
+        sboms=[],
+        ui_automation_rule_ids=ui_automation_rule_ids,
+    )
+
+    data = api_request.data
+    assert "operations" not in data
+    assert "map" not in data
+    assert "query" in data
+    assert "variables" in data
+
+    variables = json.loads(data["variables"])
+    assert variables["uiAutomationRuleInstances"] == [
+        {"ruleId": 7, "args": [{"name": "Rule 7"}]}
+    ]

--- a/tests/apis/scan_create_test.py
+++ b/tests/apis/scan_create_test.py
@@ -1,0 +1,113 @@
+"""Unittests for the scan create API request with UI automation rules."""
+
+import io
+import json
+from unittest import mock
+
+from ostorlab.apis import scan_create
+
+
+def testCreateMobileScanAPIRequest_whenUIAutomationRulesProvided_includesUIAutomationRulesInVariables():
+    """Test CreateMobileScanAPIRequest includes UI automation rules in GraphQL variables."""
+    ui_automation_rules = [
+        {"rule_id": 1, "args": [{"name": "username", "value": "testuser"}]}
+    ]
+
+    file_mock = mock.Mock(spec=io.FileIO)
+    api_request = scan_create.CreateMobileScanAPIRequest(
+        title="Test Scan",
+        asset_type=scan_create.MobileAssetType.ANDROID,
+        scan_profile="Full Scan",
+        application=file_mock,
+        sboms=[],
+        ui_automation_rule_instances=ui_automation_rules,
+    )
+
+    data = api_request.data
+    operations = json.loads(data["operations"])
+    variables = operations["variables"]
+    assert "uiAutomationRuleInstances" in variables
+    assert variables["uiAutomationRuleInstances"] == ui_automation_rules
+
+
+def testCreateMobileScanAPIRequest_whenUIAutomationRulesNotProvided_setsNullInVariables():
+    """Test CreateMobileScanAPIRequest sets null for UI automation rules when not provided."""
+    file_mock = mock.Mock(spec=io.FileIO)
+    api_request = scan_create.CreateMobileScanAPIRequest(
+        title="Test Scan",
+        asset_type=scan_create.MobileAssetType.ANDROID,
+        scan_profile="Full Scan",
+        application=file_mock,
+        sboms=[],
+    )
+
+    data = api_request.data
+    operations = json.loads(data["operations"])
+    variables = operations["variables"]
+    assert "uiAutomationRuleInstances" in variables
+    assert variables["uiAutomationRuleInstances"] is None
+
+
+def testCreateWebScanAPIRequest_whenUIAutomationRulesProvided_includesUIAutomationRulesInVariables():
+    """Test CreateWebScanAPIRequest includes UI automation rules in GraphQL variables."""
+    ui_automation_rules = [
+        {"rule_id": 2, "args": [{"name": "password", "value": "testpass"}]}
+    ]
+
+    api_request = scan_create.CreateWebScanAPIRequest(
+        title="Test Web Scan",
+        urls=["https://example.com"],
+        scan_profile="Full Scan",
+        sboms=[],
+        ui_automation_rule_instances=ui_automation_rules,
+    )
+
+    data = api_request.data
+    variables = json.loads(data["variables"])
+    assert "uiAutomationRuleInstances" in variables
+    assert variables["uiAutomationRuleInstances"] == ui_automation_rules
+
+
+def testCreateWebScanAPIRequest_whenUIAutomationRulesNotProvided_setsNullInVariables():
+    """Test CreateWebScanAPIRequest sets null for UI automation rules when not provided."""
+    api_request = scan_create.CreateWebScanAPIRequest(
+        title="Test Web Scan",
+        urls=["https://example.com"],
+        scan_profile="Full Scan",
+        sboms=[],
+    )
+
+    data = api_request.data
+    variables = json.loads(data["variables"])
+    assert "uiAutomationRuleInstances" in variables
+    assert variables["uiAutomationRuleInstances"] is None
+
+
+def testCreateMobileScanAPIRequest_UIAutomationRulesInQuery():
+    """Test CreateMobileScanAPIRequest includes UI automation rules in GraphQL query."""
+    file_mock = mock.Mock(spec=io.FileIO)
+    api_request = scan_create.CreateMobileScanAPIRequest(
+        title="Test Scan",
+        asset_type=scan_create.MobileAssetType.ANDROID,
+        scan_profile="Full Scan",
+        application=file_mock,
+        sboms=[],
+        ui_automation_rule_instances=[],
+    )
+
+    query = api_request.query
+    assert "uiAutomationRuleInstances: $uiAutomationRuleInstances" in query
+
+
+def testCreateWebScanAPIRequest_UIAutomationRulesInQuery():
+    """Test CreateWebScanAPIRequest includes UI automation rules in GraphQL query."""
+    api_request = scan_create.CreateWebScanAPIRequest(
+        title="Test Web Scan",
+        urls=["https://example.com"],
+        scan_profile="Full Scan",
+        sboms=[],
+        ui_automation_rule_instances=[],
+    )
+
+    query = api_request.query
+    assert "uiAutomationRuleInstances: $uiAutomationRuleInstances" in query

--- a/tests/apis/scan_create_test.py
+++ b/tests/apis/scan_create_test.py
@@ -37,7 +37,8 @@ def testCreateUIPromptsAPIRequest_whenUIPromptsProvided_includesUIPromptsInVaria
     data = api_request.data
     assert "query" in data
     assert "variables" in data
-    assert data["variables"]["uiPrompts"] == ui_prompts
+    variables = json.loads(data["variables"])
+    assert variables["uiPrompts"] == ui_prompts
 
 
 def testCreateUIPromptsAPIRequest_whenCalled_returnsNoFiles() -> None:


### PR DESCRIPTION
###  Add support for ui automation rules in ostorlab CI/CD pipeline

Tested with: 

```yaml
on:
  pull_request:
    branches: [ "*" ]
  push:
    branches: [ "main" ]
jobs:
  action_with_ui_automation:
    runs-on: ubuntu-latest
    name: Test ostorlab CI actions with UI automation.
    steps:
      - uses: actions/checkout@v2
      - name: build ostorlab.apk
        run: cp tests/InsecureBankv2.apk ostorlab.apk && cp tests/package-lock.json package-lock.json
      - name: Launch Ostorlab scan with UI automation
        id: start_scan
        uses: ./
        with:
          scan_profile: fast_scan # Specify which scan profile to use for the scan (check scan section).
          asset_type: android-apk # type of asset to scan.
          target: ostorlab.apk # path for target tto scan.
          scan_title: title_scan_ci_ui_automation # type a title for your scan.
          ostorlab_api_key: ${{ secrets.ostorlab_api_key }} # your secret api key.
          break_on_risk_rating: HIGH # Wait for the scan results and force the action to fail if the scan risk is higher
          max_wait_minutes: 30
          extra: --test-credentials-login test_login --test-credentials-password test_pass --test-credentials-role ci_role --test-credentials-name foo1 --test-credentials-value bar1 --test-credentials-name foo2 --test-credentials-value bar2 --sbom package-lock.json
          ui_prompts: |
            Click on the login button
            Enter username 'admin' and password 'password123'
            Navigate to the settings menu
            Click on account information
            Test the payment functionality
            Navigate through all main menu items

      - name: Get scan id
        run: echo "Scan Created with id ${{ steps.start_scan.outputs.scan_id }} you can access the full report at https://report.ostorlab.co/scan/${{ steps.start_scan.outputs.scan_id }}/"
```

<img width="911" height="119" alt="image" src="https://github.com/user-attachments/assets/966c0e94-6f1d-4920-8771-e304017f1e2a" />
