### PR TITLE
feature: add support for UI prompt id in ci scan

### DIFF
--- a/src/ostorlab/cli/ci_scan/run/assets/link.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/link.py
@@ -84,7 +84,7 @@ def run_link_scan(ctx: click.core.Context, url: List[str]) -> None:
                 f"creating Web scan `{title}` with profile `{scan_profile}`."
             )
 
-            ui_automation_rule_ids = []
+            ui_automation_rule_ids: List[int] = []
 
             # Handle existing UI prompt IDs
             if len(ui_prompt_ids) > 0:
@@ -102,7 +102,7 @@ def run_link_scan(ctx: click.core.Context, url: List[str]) -> None:
                         )
                     )
                     created_prompt_ids = [
-                        prompt["id"]
+                        int(prompt["id"])
                         for prompt in prompts_result["data"]["createUiPrompts"][
                             "uiPrompts"
                         ]

--- a/src/ostorlab/cli/ci_scan/run/assets/link.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/link.py
@@ -86,12 +86,10 @@ def run_link_scan(ctx: click.core.Context, url: List[str]) -> None:
 
             ui_automation_rule_ids: List[int] = []
 
-            # Handle existing UI prompt IDs
             if len(ui_prompt_ids) > 0:
                 ui_automation_rule_ids.extend(ui_prompt_ids)
                 ci_logger.info(f"Using existing UI prompts with IDs: {ui_prompt_ids}")
 
-            # Handle new UI prompts that need to be created
             if len(ui_prompts) > 0:
                 ui_prompts_json = [{"code": prompt} for prompt in ui_prompts]
                 try:

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -86,12 +86,10 @@ def run_mobile_scan(
 
             ui_automation_rule_ids: List[int] = []
 
-            # Handle existing UI prompt IDs
             if len(ui_prompt_ids) > 0:
                 ui_automation_rule_ids.extend(ui_prompt_ids)
                 ci_logger.info(f"Using existing UI prompts with IDs: {ui_prompt_ids}")
 
-            # Handle new UI prompts that need to be created
             if len(ui_prompts) > 0:
                 ui_prompts_json = [{"code": prompt} for prompt in ui_prompts]
                 try:

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -84,7 +84,7 @@ def run_mobile_scan(
             else:
                 credential_ids = []
 
-            ui_automation_rule_ids = []
+            ui_automation_rule_ids: List[int] = []
 
             # Handle existing UI prompt IDs
             if len(ui_prompt_ids) > 0:
@@ -102,7 +102,7 @@ def run_mobile_scan(
                         )
                     )
                     created_prompt_ids = [
-                        prompt["id"]
+                        int(prompt["id"])
                         for prompt in prompts_result["data"]["createUiPrompts"][
                             "uiPrompts"
                         ]

--- a/src/ostorlab/cli/ci_scan/run/assets/mobile.py
+++ b/src/ostorlab/cli/ci_scan/run/assets/mobile.py
@@ -70,6 +70,7 @@ def run_mobile_scan(
         branch = ctx.obj["branch"]
         scope_urls_regexes = ctx.obj["scope_urls_regexes"]
         ui_prompts = ctx.obj.get("ui_prompts") or []
+        ui_prompt_ids = ctx.obj.get("ui_prompt_ids") or []
         runner = authenticated_runner.AuthenticatedAPIRunner(
             api_key=ctx.obj.get("api_key")
         )
@@ -84,6 +85,13 @@ def run_mobile_scan(
                 credential_ids = []
 
             ui_automation_rule_ids = []
+
+            # Handle existing UI prompt IDs
+            if len(ui_prompt_ids) > 0:
+                ui_automation_rule_ids.extend(ui_prompt_ids)
+                ci_logger.info(f"Using existing UI prompts with IDs: {ui_prompt_ids}")
+
+            # Handle new UI prompts that need to be created
             if len(ui_prompts) > 0:
                 ui_prompts_json = [{"code": prompt} for prompt in ui_prompts]
                 try:
@@ -93,15 +101,14 @@ def run_mobile_scan(
                             ui_prompts=ui_prompts_json
                         )
                     )
-                    ui_automation_rule_ids = [
+                    created_prompt_ids = [
                         prompt["id"]
                         for prompt in prompts_result["data"]["createUiPrompts"][
                             "uiPrompts"
                         ]
                     ]
-                    ci_logger.info(
-                        f"Created UI prompts with IDs: {ui_automation_rule_ids}"
-                    )
+                    ui_automation_rule_ids.extend(created_prompt_ids)
+                    ci_logger.info(f"Created UI prompts with IDs: {created_prompt_ids}")
                 except (json.JSONDecodeError, KeyError) as e:
                     ci_logger.error(
                         f"Invalid UI prompts format: {e}. Continuing without UI prompts."

--- a/src/ostorlab/cli/ci_scan/run/run.py
+++ b/src/ostorlab/cli/ci_scan/run/run.py
@@ -166,6 +166,15 @@ CI_LOGGER = {
     multiple=True,
     default=[],
 )
+@click.option(
+    "--ui-prompt-id",
+    "ui_prompt_ids",
+    help="IDs of existing UI prompts to use during the scan.",
+    required=False,
+    multiple=True,
+    default=[],
+    type=int,
+)
 @click.pass_context
 def run(
     ctx: click.core.Context,
@@ -187,6 +196,7 @@ def run(
     proxy: str,
     qps: int,
     ui_prompts: List[str],
+    ui_prompt_ids: List[int],
     source: Optional[str] = None,
     repository: Optional[str] = None,
     pr_number: Optional[str] = None,
@@ -246,6 +256,7 @@ def run(
     ctx.obj["pr_number"] = pr_number
     ctx.obj["branch"] = branch
     ctx.obj["ui_prompts"] = ui_prompts
+    ctx.obj["ui_prompt_ids"] = ui_prompt_ids
 
 
 def apply_break_scan_risk_rating(


### PR DESCRIPTION
feature: add support for UI prompt id in ci scan

PS: The API Key in the screen was revoked :)

<img width="1833" height="185" alt="image" src="https://github.com/user-attachments/assets/3d869cde-e9dc-4efe-a2c0-9a7284022661" />
<img width="1907" height="137" alt="image" src="https://github.com/user-attachments/assets/9cc3fa45-68dd-4f33-b3d8-f9c1cfccc266" />

