### PR TITLE
fix: Upgrade protobuf to 5.29.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     docker
     importlib-metadata
     jsonschema>=4.4.0
-    protobuf==3.20.1
+    protobuf==5.29.5
     httpx
     rich
     ruamel.yaml

--- a/src/ostorlab/runtimes/definitions.py
+++ b/src/ostorlab/runtimes/definitions.py
@@ -161,7 +161,8 @@ class AgentSettings:
         instance.replicas = self.replicas
         instance.healthcheck_host = self.healthcheck_host
         instance.healthcheck_port = self.healthcheck_port
-        instance.caps.extend(self.caps)
+        if self.caps is not None:
+            instance.caps.extend(self.caps)
 
         if self.cyclic_processing_limit is not None:
             instance.cyclic_processing_limit = self.cyclic_processing_limit


### PR DESCRIPTION
  ## Summary
  - Upgrade protobuf from 3.20.1 to 5.29.5
  - Fix compatibility issue with caps field null handling

  ## Changes
  - Updated protobuf dependency to 5.29.5 in setup.cfg
  - Added null check for caps field in AgentSettings.to_raw_proto()

  ## Details
  Protobuf 5.x introduced stricter type validation that required a fix for the `caps` field handling. The field was defined as
  `Optional[List[str]] = None` but the code called `extend()` without checking for None.