### PR TITLE
fix: adding test for risk field in vuln in protobuf

### DIFF
--- a/tests/assets/vulnerability_test.py
+++ b/tests/assets/vulnerability_test.py
@@ -6,33 +6,35 @@ from ostorlab.agent.message import serializer
 def testVulnerabilityToProto_whenVulnerabilityWithRiskField_generatesProto():
     """Test serializing and deserializing vulnerability message with risk field."""
     vulnerability_data = {
-        'title': 'Test Vulnerability',
-        'risk_rating': 'HIGH',
-        'short_description': 'This is a test vulnerability',
-        'description': 'This is a detailed description of the test vulnerability',
-        'recommendation': 'Fix the vulnerability',
-        'technical_detail': 'Technical details about the vulnerability',
-        'risk': 'This is the risk description that needs to be included',
-        'dna': '12345',
-        'cvss_v3_vector': '5:6:7'
+        "title": "Test Vulnerability",
+        "risk_rating": "HIGH",
+        "short_description": "This is a test vulnerability",
+        "description": "This is a detailed description of the test vulnerability",
+        "recommendation": "Fix the vulnerability",
+        "technical_detail": "Technical details about the vulnerability",
+        "risk": "This is the risk description that needs to be included",
+        "dna": "12345",
+        "cvss_v3_vector": "5:6:7",
     }
-    
+
     # Serialize vulnerability
-    proto_message = serializer.serialize('v3.report.vulnerability', vulnerability_data)
+    proto_message = serializer.serialize("v3.report.vulnerability", vulnerability_data)
     raw = proto_message.SerializeToString()
 
     assert isinstance(raw, bytes)
-    
+
     # Deserialize vulnerability
-    unraw = serializer.deserialize('v3.report.vulnerability', raw)
-    
+    unraw = serializer.deserialize("v3.report.vulnerability", raw)
+
     # Check the deserialized values
-    assert unraw.title == 'Test Vulnerability'
+    assert unraw.title == "Test Vulnerability"
     assert unraw.risk_rating == 0  # HIGH is 0 in the enum
-    assert unraw.short_description == 'This is a test vulnerability'
-    assert unraw.description == 'This is a detailed description of the test vulnerability'
-    assert unraw.recommendation == 'Fix the vulnerability'
-    assert unraw.technical_detail == 'Technical details about the vulnerability'
-    assert unraw.risk == 'This is the risk description that needs to be included'
-    assert unraw.dna == '12345'
-    assert unraw.cvss_v3_vector == '5:6:7'
+    assert unraw.short_description == "This is a test vulnerability"
+    assert (
+        unraw.description == "This is a detailed description of the test vulnerability"
+    )
+    assert unraw.recommendation == "Fix the vulnerability"
+    assert unraw.technical_detail == "Technical details about the vulnerability"
+    assert unraw.risk == "This is the risk description that needs to be included"
+    assert unraw.dna == "12345"
+    assert unraw.cvss_v3_vector == "5:6:7"

--- a/tests/assets/vulnerability_test.py
+++ b/tests/assets/vulnerability_test.py
@@ -1,0 +1,38 @@
+"""Unit tests for Vulnerability serialization."""
+
+from ostorlab.agent.message import serializer
+
+
+def testVulnerabilityToProto_whenVulnerabilityWithRiskField_generatesProto():
+    """Test serializing and deserializing vulnerability message with risk field."""
+    vulnerability_data = {
+        'title': 'Test Vulnerability',
+        'risk_rating': 'HIGH',
+        'short_description': 'This is a test vulnerability',
+        'description': 'This is a detailed description of the test vulnerability',
+        'recommendation': 'Fix the vulnerability',
+        'technical_detail': 'Technical details about the vulnerability',
+        'risk': 'This is the risk description that needs to be included',
+        'dna': '12345',
+        'cvss_v3_vector': '5:6:7'
+    }
+    
+    # Serialize vulnerability
+    proto_message = serializer.serialize('v3.report.vulnerability', vulnerability_data)
+    raw = proto_message.SerializeToString()
+
+    assert isinstance(raw, bytes)
+    
+    # Deserialize vulnerability
+    unraw = serializer.deserialize('v3.report.vulnerability', raw)
+    
+    # Check the deserialized values
+    assert unraw.title == 'Test Vulnerability'
+    assert unraw.risk_rating == 0  # HIGH is 0 in the enum
+    assert unraw.short_description == 'This is a test vulnerability'
+    assert unraw.description == 'This is a detailed description of the test vulnerability'
+    assert unraw.recommendation == 'Fix the vulnerability'
+    assert unraw.technical_detail == 'Technical details about the vulnerability'
+    assert unraw.risk == 'This is the risk description that needs to be included'
+    assert unraw.dna == '12345'
+    assert unraw.cvss_v3_vector == '5:6:7'


### PR DESCRIPTION
This pull request adds a new unit test for the serialization and deserialization of vulnerability messages, specifically verifying that the `risk` field is correctly handled.

Testing improvements:

* Added a unit test `testVulnerabilityToProto_whenVulnerabilityWithRiskField_generatesProto` in `tests/assets/vulnerability_test.py` to ensure that vulnerability messages with a `risk` field are properly serialized and deserialized, and all expected fields are correctly mapped.