### PR TITLE
fix: update Risk message

### DIFF
--- a/src/ostorlab/agent/message/proto/v3/report/risk/risk.proto
+++ b/src/ostorlab/agent/message/proto/v3/report/risk/risk.proto
@@ -1,30 +1,8 @@
 syntax = "proto2";
 
-import 'ostorlab/agent/message/proto/v3/asset/domain_name/domain_name.proto';
-import 'ostorlab/agent/message/proto/v3/asset/ip/v4/v4.proto';
-import 'ostorlab/agent/message/proto/v3/asset/ip/v6/v6.proto';
-import 'ostorlab/agent/message/proto/v3/asset/link/link.proto';
-import 'ostorlab/agent/message/proto/v3/asset/store/android_store/android_store.proto';
-import 'ostorlab/agent/message/proto/v3/asset/store/ios_store/ios_store.proto';
-import 'ostorlab/agent/message/proto/v3/asset/file/file.proto';
-import 'ostorlab/agent/message/proto/v3/asset/file/android/aab/aab.proto';
-import 'ostorlab/agent/message/proto/v3/asset/file/android/apk/apk.proto';
-import 'ostorlab/agent/message/proto/v3/asset/file/ios/ipa/ipa.proto';
-
 package ostorlab.agent.message.proto.v3.report.risk;
 
 message Risk {
-  oneof asset {
-    ostorlab.agent.message.proto.v3.asset.domain_name.Message domain_name = 1;
-    ostorlab.agent.message.proto.v3.asset.ip.v4.Message ipv4 = 2;
-    ostorlab.agent.message.proto.v3.asset.ip.v6.Message ipv6 = 3;
-    ostorlab.agent.message.proto.v3.asset.link.Message link = 4;
-    ostorlab.agent.message.proto.v3.asset.store.android_store.Message android_store = 5;
-    ostorlab.agent.message.proto.v3.asset.store.ios_store.Message ios_store = 6;
-    ostorlab.agent.message.proto.v3.asset.file.Message file = 7;
-    ostorlab.agent.message.proto.v3.asset.file.android.aab.Message android_aab = 8;
-    ostorlab.agent.message.proto.v3.asset.file.android.apk.Message android_apk = 9;
-    ostorlab.agent.message.proto.v3.asset.file.ios.ipa.Message ios_ipa = 10;
-  }
-  required string description = 100;
+  required string description = 1;
+  required string rating = 2;
 }

--- a/src/ostorlab/agent/message/proto/v3/report/risk/risk_pb2.py
+++ b/src/ostorlab/agent/message/proto/v3/report/risk/risk_pb2.py
@@ -11,25 +11,15 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-from ostorlab.agent.message.proto.v3.asset.domain_name import domain_name_pb2 as ostorlab_dot_agent_dot_message_dot_proto_dot_v3_dot_asset_dot_domain__name_dot_domain__name__pb2
-from ostorlab.agent.message.proto.v3.asset.ip.v4 import v4_pb2 as ostorlab_dot_agent_dot_message_dot_proto_dot_v3_dot_asset_dot_ip_dot_v4_dot_v4__pb2
-from ostorlab.agent.message.proto.v3.asset.ip.v6 import v6_pb2 as ostorlab_dot_agent_dot_message_dot_proto_dot_v3_dot_asset_dot_ip_dot_v6_dot_v6__pb2
-from ostorlab.agent.message.proto.v3.asset.link import link_pb2 as ostorlab_dot_agent_dot_message_dot_proto_dot_v3_dot_asset_dot_link_dot_link__pb2
-from ostorlab.agent.message.proto.v3.asset.store.android_store import android_store_pb2 as ostorlab_dot_agent_dot_message_dot_proto_dot_v3_dot_asset_dot_store_dot_android__store_dot_android__store__pb2
-from ostorlab.agent.message.proto.v3.asset.store.ios_store import ios_store_pb2 as ostorlab_dot_agent_dot_message_dot_proto_dot_v3_dot_asset_dot_store_dot_ios__store_dot_ios__store__pb2
-from ostorlab.agent.message.proto.v3.asset.file import file_pb2 as ostorlab_dot_agent_dot_message_dot_proto_dot_v3_dot_asset_dot_file_dot_file__pb2
-from ostorlab.agent.message.proto.v3.asset.file.android.aab import aab_pb2 as ostorlab_dot_agent_dot_message_dot_proto_dot_v3_dot_asset_dot_file_dot_android_dot_aab_dot_aab__pb2
-from ostorlab.agent.message.proto.v3.asset.file.android.apk import apk_pb2 as ostorlab_dot_agent_dot_message_dot_proto_dot_v3_dot_asset_dot_file_dot_android_dot_apk_dot_apk__pb2
-from ostorlab.agent.message.proto.v3.asset.file.ios.ipa import ipa_pb2 as ostorlab_dot_agent_dot_message_dot_proto_dot_v3_dot_asset_dot_file_dot_ios_dot_ipa_dot_ipa__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n6ostorlab/agent/message/proto/v3/report/risk/risk.proto\x12+ostorlab.agent.message.proto.v3.report.risk\x1a\x43ostorlab/agent/message/proto/v3/asset/domain_name/domain_name.proto\x1a\x34ostorlab/agent/message/proto/v3/asset/ip/v4/v4.proto\x1a\x34ostorlab/agent/message/proto/v3/asset/ip/v6/v6.proto\x1a\x35ostorlab/agent/message/proto/v3/asset/link/link.proto\x1aMostorlab/agent/message/proto/v3/asset/store/android_store/android_store.proto\x1a\x45ostorlab/agent/message/proto/v3/asset/store/ios_store/ios_store.proto\x1a\x35ostorlab/agent/message/proto/v3/asset/file/file.proto\x1a@ostorlab/agent/message/proto/v3/asset/file/android/aab/aab.proto\x1a@ostorlab/agent/message/proto/v3/asset/file/android/apk/apk.proto\x1a<ostorlab/agent/message/proto/v3/asset/file/ios/ipa/ipa.proto\"\xbf\x06\n\x04Risk\x12Q\n\x0b\x64omain_name\x18\x01 \x01(\x0b\x32:.ostorlab.agent.message.proto.v3.asset.domain_name.MessageH\x00\x12\x44\n\x04ipv4\x18\x02 \x01(\x0b\x32\x34.ostorlab.agent.message.proto.v3.asset.ip.v4.MessageH\x00\x12\x44\n\x04ipv6\x18\x03 \x01(\x0b\x32\x34.ostorlab.agent.message.proto.v3.asset.ip.v6.MessageH\x00\x12\x43\n\x04link\x18\x04 \x01(\x0b\x32\x33.ostorlab.agent.message.proto.v3.asset.link.MessageH\x00\x12[\n\randroid_store\x18\x05 \x01(\x0b\x32\x42.ostorlab.agent.message.proto.v3.asset.store.android_store.MessageH\x00\x12S\n\tios_store\x18\x06 \x01(\x0b\x32>.ostorlab.agent.message.proto.v3.asset.store.ios_store.MessageH\x00\x12\x43\n\x04\x66ile\x18\x07 \x01(\x0b\x32\x33.ostorlab.agent.message.proto.v3.asset.file.MessageH\x00\x12V\n\x0b\x61ndroid_aab\x18\x08 \x01(\x0b\x32?.ostorlab.agent.message.proto.v3.asset.file.android.aab.MessageH\x00\x12V\n\x0b\x61ndroid_apk\x18\t \x01(\x0b\x32?.ostorlab.agent.message.proto.v3.asset.file.android.apk.MessageH\x00\x12N\n\x07ios_ipa\x18\n \x01(\x0b\x32;.ostorlab.agent.message.proto.v3.asset.file.ios.ipa.MessageH\x00\x12\x13\n\x0b\x64\x65scription\x18\x64 \x02(\tB\x07\n\x05\x61sset')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n6ostorlab/agent/message/proto/v3/report/risk/risk.proto\x12+ostorlab.agent.message.proto.v3.report.risk\"+\n\x04Risk\x12\x13\n\x0b\x64\x65scription\x18\x01 \x02(\t\x12\x0e\n\x06rating\x18\x02 \x02(\t')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'ostorlab.agent.message.proto.v3.report.risk.risk_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _RISK._serialized_start=735
-  _RISK._serialized_end=1566
+  _RISK._serialized_start=103
+  _RISK._serialized_end=146
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
Refactored the `Risk` proto message to remove the oneof asset field, retaining only a description (now field 1) and adding a new rating field to align with other components