### PR TITLE
fix: remove the log

### DIFF
--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -247,7 +247,7 @@ class AgentMixin(
             logger.error(
                 "Message of selector %s: %s",
                 object_message.selector,
-                string_utils.to_string(object_message.data),
+                string_utils.format_dict(object_message.data),
             )
         finally:
             self.process_cleanup()

--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -28,6 +28,7 @@ from ostorlab.agent.mixins import agent_mq_mixin
 from ostorlab.agent.mixins import agent_open_telemetry_mixin as open_telemetry_mixin
 from ostorlab.runtimes import definitions as runtime_definitions
 from ostorlab.utils import system
+from ostorlab.utils import strings as string_utils
 
 GCP_LOGGING_CREDENTIAL_ENV = "GCP_LOGGING_CREDENTIAL"
 
@@ -243,7 +244,11 @@ class AgentMixin(
             if system_info is not None:
                 logger.error("System Info: %s", system_info)
             logger.exception("Exception: %s", e)
-            logger.error("Message: %s", object_message.selector)
+            logger.error(
+                "Message of selector %s: %s",
+                object_message.selector,
+                string_utils.to_string(object_message.data),
+            )
         finally:
             self.process_cleanup()
             logger.debug("done call to process message")

--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -242,8 +242,8 @@ class AgentMixin(
             system_info = system.get_system_info()
             if system_info is not None:
                 logger.error("System Info: %s", system_info)
-            logger.error("Message: %s", object_message)
             logger.exception("Exception: %s", e)
+            logger.error("Message: %s", object_message.selector)
         finally:
             self.process_cleanup()
             logger.debug("done call to process message")

--- a/src/ostorlab/utils/strings.py
+++ b/src/ostorlab/utils/strings.py
@@ -39,7 +39,7 @@ def _format_data(data: Any) -> Any:
         return data
 
 
-def to_string(dict_obj: dict[str, Any]) -> str:
+def format_dict(dict_obj: dict[str, Any]) -> str:
     """Format message for logging, filtering out large values."""
     filtered_data = _format_data(dict_obj)
     return json.dumps(filtered_data, indent=2)

--- a/src/ostorlab/utils/strings.py
+++ b/src/ostorlab/utils/strings.py
@@ -1,7 +1,9 @@
 """Utils to generate and manipulate strings."""
 
+import json
 import random
 import string
+from typing import Any
 
 
 def random_string(length: int, alphabet: str = string.ascii_lowercase) -> str:
@@ -19,3 +21,25 @@ def random_string(length: int, alphabet: str = string.ascii_lowercase) -> str:
 
     result = "".join((random.choice(alphabet) for _ in range(length)))
     return result
+
+
+def _format_data(data: Any) -> Any:
+    if isinstance(data, dict):
+        return {k: _format_data(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [_format_data(v) for v in data]
+    elif isinstance(data, bytes):
+        return f"<bytes of length {len(data)}>"
+    elif isinstance(data, str):
+        if len(data) > 4096:
+            return f"{data[:256]}... <string of length {len(data)}>"
+        else:
+            return data
+    else:
+        return data
+
+
+def to_string(dict_obj: dict[str, Any]) -> str:
+    """Format message for logging, filtering out large values."""
+    filtered_data = _format_data(dict_obj)
+    return json.dumps(filtered_data, indent=2)

--- a/tests/agent/agent_test.py
+++ b/tests/agent/agent_test.py
@@ -385,15 +385,12 @@ def testProcessMessage_whenExceptionRaised_shouldLogErrorWithMessageAndSystemLoa
     assert (
         isinstance(logger_error.call_args_list[0][0][1], system.SystemLoadInfo) is True
     )
-    assert (
-        isinstance(logger_error.call_args_list[1][0][1], agent_message.Message) is True
-    )
-    assert logger_error.call_args_list[1][0][1].selector == "v3.healthcheck.ping"
-    assert (
-        logger_error.call_args_list[1][0][1].data["body"] == "Hello, can you hear me?"
-    )
-    assert isinstance(logger_error.call_args_list[2][0][1], ValueError) is True
-    assert "some error" in logger_error.call_args_list[2][0][1].args[0]
+    assert "Exception: %s" in logger_error.call_args_list[1][0][0]
+    assert isinstance(logger_error.call_args_list[1][0][1], ValueError) is True
+    assert "some error" in logger_error.call_args_list[1][0][1].args[0]
+    assert "Message of selector %s: %s" in logger_error.call_args_list[2][0][0]
+    assert logger_error.call_args_list[2][0][1] == "v3.healthcheck.ping"
+    assert "Hello, can you hear me?" in logger_error.call_args_list[2][0][2]
 
 
 def testProcessMessage_whenExceptionRaisedAndPsutilNotAvailable_shouldLogErrorWithMessageAndNoSystemLoad(
@@ -442,15 +439,12 @@ def testProcessMessage_whenExceptionRaisedAndPsutilNotAvailable_shouldLogErrorWi
     )
 
     assert logger_error.call_count == 2
-    assert (
-        isinstance(logger_error.call_args_list[0][0][1], agent_message.Message) is True
-    )
-    assert logger_error.call_args_list[0][0][1].selector == "v3.healthcheck.ping"
-    assert (
-        logger_error.call_args_list[0][0][1].data["body"] == "Hello, can you hear me?"
-    )
-    assert isinstance(logger_error.call_args_list[1][0][1], ValueError) is True
-    assert "some error" in logger_error.call_args_list[1][0][1].args[0]
+    assert "Exception: %s" in logger_error.call_args_list[0][0][0]
+    assert isinstance(logger_error.call_args_list[0][0][1], ValueError) is True
+    assert "some error" in logger_error.call_args_list[0][0][1].args[0]
+    assert "Message of selector %s: %s" in logger_error.call_args_list[1][0][0]
+    assert logger_error.call_args_list[1][0][1] == "v3.healthcheck.ping"
+    assert "Hello, can you hear me?" in logger_error.call_args_list[1][0][2]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Does not run on windows")

--- a/tests/utils/strings_test.py
+++ b/tests/utils/strings_test.py
@@ -18,3 +18,53 @@ def testRandomString_whenLengthIsInvalid_raisesAnException():
     """Tests if an exception is raised when a incorrect length value is provided."""
     with pytest.raises(ValueError):
         strings.random_string(0)
+
+
+def testToString_whenDictHasLongString_returnsTruncatedString():
+    """Tests if a long string is truncated."""
+    long_string = "a" * 5000
+    data = {"a": long_string}
+    result = strings.to_string(data)
+    assert f'"{long_string[:256]}... <string of length {len(long_string)}>"' in result
+
+
+def testToString_whenDictHasShortString_returnsFullString():
+    """Tests if a short string is not truncated."""
+    short_string = "a" * 100
+    data = {"a": short_string}
+    result = strings.to_string(data)
+    assert f'"{short_string}"' in result
+    assert "<string of length" not in result
+
+
+def testToString_whenDictHasBytes_returnsBytesPlaceholder():
+    """Tests if bytes are replaced with a placeholder."""
+    data = {"a": b"test"}
+    result = strings.to_string(data)
+    assert '"<bytes of length 4>"' in result
+
+
+def testToString_whenDictIsNested_returnsFilteredString():
+    """Tests if nested dict is filtered."""
+    long_string = "a" * 5000
+    data = {"a": {"b": long_string}}
+    result = strings.to_string(data)
+    assert f'"{long_string[:256]}... <string of length {len(long_string)}>"' in result
+
+
+def testToString_whenDictHasList_returnsFilteredString():
+    """Tests if list elements are filtered."""
+    long_string = "a" * 5000
+    data = {"a": [long_string, b"test"]}
+    result = strings.to_string(data)
+    assert f'"{long_string[:256]}... <string of length {len(long_string)}>"' in result
+    assert '"<bytes of length 4>"' in result
+
+
+def testToString_whenObjectIsNotStringOrBytes_returnsObject():
+    """Tests if an object that is not a string or bytes is returned as is."""
+    data = {"a": 123, "b": True, "c": None}
+    result = strings.to_string(data)
+    assert '"a": 123' in result
+    assert '"b": true' in result
+    assert '"c": null' in result

--- a/tests/utils/strings_test.py
+++ b/tests/utils/strings_test.py
@@ -24,7 +24,7 @@ def testToString_whenDictHasLongString_returnsTruncatedString():
     """Tests if a long string is truncated."""
     long_string = "a" * 5000
     data = {"a": long_string}
-    result = strings.to_string(data)
+    result = strings.format_dict(data)
     assert f'"{long_string[:256]}... <string of length {len(long_string)}>"' in result
 
 
@@ -32,7 +32,7 @@ def testToString_whenDictHasShortString_returnsFullString():
     """Tests if a short string is not truncated."""
     short_string = "a" * 100
     data = {"a": short_string}
-    result = strings.to_string(data)
+    result = strings.format_dict(data)
     assert f'"{short_string}"' in result
     assert "<string of length" not in result
 
@@ -40,7 +40,7 @@ def testToString_whenDictHasShortString_returnsFullString():
 def testToString_whenDictHasBytes_returnsBytesPlaceholder():
     """Tests if bytes are replaced with a placeholder."""
     data = {"a": b"test"}
-    result = strings.to_string(data)
+    result = strings.format_dict(data)
     assert '"<bytes of length 4>"' in result
 
 
@@ -48,7 +48,7 @@ def testToString_whenDictIsNested_returnsFilteredString():
     """Tests if nested dict is filtered."""
     long_string = "a" * 5000
     data = {"a": {"b": long_string}}
-    result = strings.to_string(data)
+    result = strings.format_dict(data)
     assert f'"{long_string[:256]}... <string of length {len(long_string)}>"' in result
 
 
@@ -56,7 +56,7 @@ def testToString_whenDictHasList_returnsFilteredString():
     """Tests if list elements are filtered."""
     long_string = "a" * 5000
     data = {"a": [long_string, b"test"]}
-    result = strings.to_string(data)
+    result = strings.format_dict(data)
     assert f'"{long_string[:256]}... <string of length {len(long_string)}>"' in result
     assert '"<bytes of length 4>"' in result
 
@@ -64,7 +64,7 @@ def testToString_whenDictHasList_returnsFilteredString():
 def testToString_whenObjectIsNotStringOrBytes_returnsObject():
     """Tests if an object that is not a string or bytes is returned as is."""
     data = {"a": 123, "b": True, "c": None}
-    result = strings.to_string(data)
+    result = strings.format_dict(data)
     assert '"a": 123' in result
     assert '"b": true' in result
     assert '"c": null' in result


### PR DESCRIPTION
When the message is large, like `v3.asset.file.android`, logging it can cause a buffer overflow and floods the entire terminal with binary gibberish making debugging a pain. In general, we should avoid logging entire application files.