### PR TITLE
feature: Add no-tracker flag to allw running scans without stopping.

### DIFF
--- a/src/ostorlab/cli/scan/run/run.py
+++ b/src/ostorlab/cli/scan/run/run.py
@@ -84,6 +84,13 @@ WAIT_BETWEEN_RETRIES = 5
     required=False,
 )
 @click.option(
+    "--no-tracker",
+    help="Start the scan without tracker in charge of handling scan completion tracking.",
+    is_flag=True,
+    default=False,
+    required=False,
+)
+@click.option(
     "--no-asset",
     help="Start the environment without injecting assets",
     is_flag=True,
@@ -113,6 +120,7 @@ def run(
     install: bool,
     follow: List[str],
     no_follow: bool,
+    no_tracker: bool,
     no_asset: bool,
     timeout: Optional[int] = None,
     init_sleep: Optional[int] = None,
@@ -161,6 +169,10 @@ def run(
             console.error(f"{e}")
             raise click.ClickException("Invalid asset Group Definition.") from e
     runtime_instance: runtime.Runtime = ctx.obj["runtime"]
+
+    if no_tracker is True:
+        runtime_instance.has_tracker = False
+
     if timeout is not None:
         runtime_instance.timeout = timeout
 

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -494,6 +494,9 @@ class LocalRuntime(runtime.Runtime):
 
     def _start_tracker_agent(self):
         """Start the tracker agent to handle the scan lifecycle."""
+        if self.has_tracker is False:
+            return
+
         tracker_agent_settings = definitions.AgentSettings(
             key=TRACKER_AGENT_DEFAULT,
         )

--- a/src/ostorlab/runtimes/runtime.py
+++ b/src/ostorlab/runtimes/runtime.py
@@ -26,6 +26,7 @@ class Runtime(abc.ABC):
     follow: list
     timeout: Optional[int] = None
     init_sleep: Optional[int] = None
+    has_tracker: bool = True
 
     @abc.abstractmethod
     def can_run(self, agent_group_definition: definitions.AgentGroupDefinition) -> bool:


### PR DESCRIPTION
Using `--no-tracker` and tracker won't start and scan won't stop.

Helpful when debugging MCP servers.