### PR TITLE
fix: add labels to differentiate instances of the same agent

### DIFF
--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -50,7 +50,7 @@ class MaximumDepthProcessReachedError(exceptions.OstorlabError):
 
 
 def _setup_logging(
-    instance_id: str, hostname: str, agent_key: str, agent_version: str, universe: str
+    hostname: str, agent_key: str, agent_version: str, universe: str
 ) -> None:
     gcp_logging_credential = os.environ.get(GCP_LOGGING_CREDENTIAL_ENV)
     if gcp_logging_credential is not None:
@@ -69,7 +69,6 @@ def _setup_logging(
                     "agent_version": agent_version,
                     "universe": universe,
                     "hostname": hostname,
-                    "id": instance_id,
                 }
             )
         except ImportError:
@@ -480,10 +479,7 @@ class AgentMixin(
                 f_settings.read()
             )
 
-            instance_id = str(uuid.uuid4())
-            os.environ["INSTANCE_ID"] = instance_id
             _setup_logging(
-                instance_id=instance_id,
                 hostname=os.getenv("HOSTNAME"),
                 agent_key=agent_settings.key,
                 agent_version=agent_definition.version or "latest",

--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -480,8 +480,10 @@ class AgentMixin(
                 f_settings.read()
             )
 
+            instance_id = str(uuid.uuid4())
+            os.environ["INSTANCE_ID"] = instance_id
             _setup_logging(
-                instance_id=str(uuid.uuid4()),
+                instance_id=instance_id,
                 hostname=os.getenv("HOSTNAME"),
                 agent_key=agent_settings.key,
                 agent_version=agent_definition.version or "latest",

--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -49,7 +49,9 @@ class MaximumDepthProcessReachedError(exceptions.OstorlabError):
     """The processing depth limit is enforced and reached the limit."""
 
 
-def _setup_logging(agent_key: str, agent_version: str, universe: str) -> None:
+def _setup_logging(
+    instance_id: str, hostname: str, agent_key: str, agent_version: str, universe: str
+) -> None:
     gcp_logging_credential = os.environ.get(GCP_LOGGING_CREDENTIAL_ENV)
     if gcp_logging_credential is not None:
         try:
@@ -66,6 +68,8 @@ def _setup_logging(agent_key: str, agent_version: str, universe: str) -> None:
                     "agent_key": agent_key,
                     "agent_version": agent_version,
                     "universe": universe,
+                    "hostname": hostname,
+                    "id": instance_id,
                 }
             )
         except ImportError:
@@ -477,6 +481,8 @@ class AgentMixin(
             )
 
             _setup_logging(
+                instance_id=str(uuid.uuid4()),
+                hostname=os.getenv("HOSTNAME"),
                 agent_key=agent_settings.key,
                 agent_version=agent_definition.version or "latest",
                 universe=os.environ.get("UNIVERSE"),


### PR DESCRIPTION
In scans with multiple instances per agent, we cannot differentiate the logs of one instance from another and they get mixed up. in the logs which make it hard to debug.

 In this PR  two gcp labels have been added:
- `hostname`: The `hostname` of the docker container, which defaults to the container ID, read from `HOSTNAME` env var. This is unique unless overridden. Helps identifying the running container that issued the logs.
- `id`: this is `uuid`, fallback in the rare case where `hostname` is not unique or not available (idk), but can't be mapped immediately to the running container.