### PR TITLE
feature: add library name metadata

### DIFF
--- a/src/ostorlab/agent/mixins/agent_report_vulnerability_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_report_vulnerability_mixin.py
@@ -32,6 +32,7 @@ class MetadataType(enum.Enum):
     VERSION = enum.auto()
     CLASS_NAME = enum.auto()
     METHOD_NAME = enum.auto()
+    LIBRARY_NAME = enum.auto()
     CALL_TRACE = enum.auto()
     INSERTION_POINT = enum.auto()
     DNS_RECORD_TYPE = enum.auto()


### PR DESCRIPTION
This PR add new metadata type library name, the reason is when emitting vuln after analyzing library asset messages, one of the information that easily identify the vuln location is library name