### PR TITLE
feature: Add Ability To Specify Service Name In Agent Group

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ python_requires = >=3.9
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
 install_requires =
-    opentelemetry-sdk==1.39.1
     click
     docker
     importlib-metadata
@@ -80,6 +79,7 @@ exclude =
 
 # Add here agents requirements (semicolon/line-separated)
 agent =
+    opentelemetry-sdk==1.39.1
     Werkzeug~=3.0
     aio-pika
     flask

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,7 @@ agent =
     google-cloud-logging
     opentelemetry-distro
     opentelemetry-exporter-jaeger
+    opentelemetry-sdk==1.39.1
     deprecated
     opentelemetry-exporter-gcp-trace
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ python_requires = >=3.9
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
 install_requires =
+    opentelemetry-sdk==1.39.1
     click
     docker
     importlib-metadata
@@ -86,7 +87,6 @@ agent =
     google-cloud-logging
     opentelemetry-distro
     opentelemetry-exporter-jaeger
-    opentelemetry-sdk==1.39.1
     deprecated
     opentelemetry-exporter-gcp-trace
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,13 +79,13 @@ exclude =
 
 # Add here agents requirements (semicolon/line-separated)
 agent =
-    opentelemetry-sdk==1.39.1
     Werkzeug~=3.0
     aio-pika
     flask
     redis
     google-cloud-logging
     opentelemetry-distro
+    opentelemetry-sdk==1.39.1
     opentelemetry-exporter-jaeger
     deprecated
     opentelemetry-exporter-gcp-trace

--- a/src/ostorlab/runtimes/definitions.py
+++ b/src/ostorlab/runtimes/definitions.py
@@ -65,6 +65,7 @@ class AgentSettings:
     depth_processing_limit: Optional[int] = None
     accepted_agents: Optional[List[str]] = None
     in_selectors: Optional[List[str]] = dataclasses.field(default_factory=list)
+    service_name: Optional[str] = None
 
     @property
     def container_image(self):
@@ -231,6 +232,7 @@ class AgentGroupDefinition:
                 depth_processing_limit=agent.get("depth_processing_limit"),
                 accepted_agents=agent.get("accepted_agents"),
                 in_selectors=agent.get("in_selectors", []),
+                service_name=agent.get("service_name"),
             )
 
             agent_settings.append(agent_def)

--- a/src/ostorlab/runtimes/lite_local/agent_runtime.py
+++ b/src/ostorlab/runtimes/lite_local/agent_runtime.py
@@ -354,12 +354,13 @@ class AgentRuntime:
         )
         caps = self.agent.caps or agent_definition.caps
 
-        if agent_definition.service_name is not None:
-            if len(agent_definition.service_name) > MAX_SERVICE_NAME_LEN:
+        resolved_service_name = self.agent.service_name or agent_definition.service_name
+        if resolved_service_name is not None:
+            if len(resolved_service_name) > MAX_SERVICE_NAME_LEN:
                 raise ServiceNameTooLong(
-                    f'service name "{agent_definition.service_name}" exceeds max length of {MAX_SERVICE_NAME_LEN}'
+                    f'service name "{resolved_service_name}" exceeds max length of {MAX_SERVICE_NAME_LEN}'
                 )
-            service_name = agent_definition.service_name
+            service_name = resolved_service_name
         else:
             service_name = (
                 self.agent.container_image.split(":")[0].replace(".", "")

--- a/src/ostorlab/runtimes/lite_local/agent_runtime.py
+++ b/src/ostorlab/runtimes/lite_local/agent_runtime.py
@@ -375,7 +375,10 @@ class AgentRuntime:
             if len(base_service_name) + len(random_suffix) <= MAX_SERVICE_NAME_LEN:
                 service_name = base_service_name + random_suffix
             else:
-                service_name = base_service_name[:MAX_SERVICE_NAME_LEN]
+                service_name = (
+                    base_service_name[: MAX_SERVICE_NAME_LEN - len(random_suffix)]
+                    + random_suffix
+                )
 
         env = [
             f"UNIVERSE={self.runtime_name}",

--- a/src/ostorlab/runtimes/lite_local/agent_runtime.py
+++ b/src/ostorlab/runtimes/lite_local/agent_runtime.py
@@ -354,24 +354,28 @@ class AgentRuntime:
         )
         caps = self.agent.caps or agent_definition.caps
 
-        resolved_service_name = self.agent.service_name or agent_definition.service_name
-        if resolved_service_name is not None:
-            if len(resolved_service_name) > MAX_SERVICE_NAME_LEN:
+        explicit_service_name = (
+            self.agent.service_name
+            if self.agent.service_name is not None
+            else agent_definition.service_name
+        )
+        if explicit_service_name is not None:
+            if len(explicit_service_name) > MAX_SERVICE_NAME_LEN:
                 raise ServiceNameTooLong(
-                    f'service name "{resolved_service_name}" exceeds max length of {MAX_SERVICE_NAME_LEN}'
+                    f'service name "{explicit_service_name}" exceeds max length of {MAX_SERVICE_NAME_LEN}'
                 )
-            service_name = resolved_service_name
+            service_name = explicit_service_name
         else:
-            service_name = (
+            base_service_name = (
                 self.agent.container_image.split(":")[0].replace(".", "")
                 + "_"
                 + self.runtime_name
             )
-
-            # We apply the random str only if it will not break the max docker service name characters (63)
-            # This is to handle the same agent declared multiple times
-            if len(service_name) + MAX_RANDOM_NAME_LEN < MAX_SERVICE_NAME_LEN:
-                service_name = service_name + "_" + str(random.randrange(0, 9999))
+            random_suffix = "_" + str(random.randrange(0, 9999))
+            if len(base_service_name) + len(random_suffix) <= MAX_SERVICE_NAME_LEN:
+                service_name = base_service_name + random_suffix
+            else:
+                service_name = base_service_name[:MAX_SERVICE_NAME_LEN]
 
         env = [
             f"UNIVERSE={self.runtime_name}",

--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -343,12 +343,13 @@ class AgentRuntime:
         )
         caps = self.agent.caps or agent_definition.caps or []
 
-        if agent_definition.service_name is not None:
-            if len(agent_definition.service_name) > MAX_SERVICE_NAME_LEN:
+        resolved_service_name = self.agent.service_name or agent_definition.service_name
+        if resolved_service_name is not None:
+            if len(resolved_service_name) > MAX_SERVICE_NAME_LEN:
                 raise ServiceNameTooLong(
-                    f'service name "{agent_definition.service_name}" exceeds max length of {MAX_SERVICE_NAME_LEN}'
+                    f'service name "{resolved_service_name}" exceeds max length of {MAX_SERVICE_NAME_LEN}'
                 )
-            service_name = agent_definition.service_name
+            service_name = resolved_service_name
         else:
             service_name = (
                 self.agent.container_image.split(":")[0].replace(".", "")

--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -364,7 +364,10 @@ class AgentRuntime:
             if len(base_service_name) + len(random_suffix) <= MAX_SERVICE_NAME_LEN:
                 service_name = base_service_name + random_suffix
             else:
-                service_name = base_service_name[:MAX_SERVICE_NAME_LEN]
+                service_name = (
+                    base_service_name[: MAX_SERVICE_NAME_LEN - len(random_suffix)]
+                    + random_suffix
+                )
 
         env = [
             f"UNIVERSE={self.runtime_name}",

--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -343,24 +343,28 @@ class AgentRuntime:
         )
         caps = self.agent.caps or agent_definition.caps or []
 
-        resolved_service_name = self.agent.service_name or agent_definition.service_name
-        if resolved_service_name is not None:
-            if len(resolved_service_name) > MAX_SERVICE_NAME_LEN:
+        explicit_service_name = (
+            self.agent.service_name
+            if self.agent.service_name is not None
+            else agent_definition.service_name
+        )
+        if explicit_service_name is not None:
+            if len(explicit_service_name) > MAX_SERVICE_NAME_LEN:
                 raise ServiceNameTooLong(
-                    f'service name "{resolved_service_name}" exceeds max length of {MAX_SERVICE_NAME_LEN}'
+                    f'service name "{explicit_service_name}" exceeds max length of {MAX_SERVICE_NAME_LEN}'
                 )
-            service_name = resolved_service_name
+            service_name = explicit_service_name
         else:
-            service_name = (
+            base_service_name = (
                 self.agent.container_image.split(":")[0].replace(".", "")
                 + "_"
                 + self.runtime_name
             )
-
-            # We apply the random str only if it will not break the max docker service name characters (63)
-            # This is to handle the same agent declared multiple times
-            if len(service_name) + MAX_RANDOM_NAME_LEN < MAX_SERVICE_NAME_LEN:
-                service_name = service_name + "_" + str(random.randrange(0, 9999))
+            random_suffix = "_" + str(random.randrange(0, 9999))
+            if len(base_service_name) + len(random_suffix) <= MAX_SERVICE_NAME_LEN:
+                service_name = base_service_name + random_suffix
+            else:
+                service_name = base_service_name[:MAX_SERVICE_NAME_LEN]
 
         env = [
             f"UNIVERSE={self.runtime_name}",

--- a/tests/runtimes/definitions_test.py
+++ b/tests/runtimes/definitions_test.py
@@ -68,6 +68,21 @@ def testAgentGroupDefinitionFromYaml_whenYamlIsValid_returnsValidAgentGroupDefin
     assert agentgrp_def.agents == dummy_agents
 
 
+def testAgentGroupDefinitionFromYaml_whenServiceNameProvided_parsedCorrectly():
+    """Test that service_name in YAML is parsed into AgentSettings."""
+    valid_yaml = """
+        kind: "AgentGroup"
+        description: "test"
+        agents:
+          - key: "agent/ostorlab/crawler"
+            service_name: "crawler_bus"
+    """
+
+    agentgrp_def = definitions.AgentGroupDefinition.from_yaml(io.StringIO(valid_yaml))
+
+    assert agentgrp_def.agents[0].service_name == "crawler_bus"
+
+
 def testAgentInstanceSettingsTo_whenProtoIsValid_returnsBytes():
     """Tests that the generated proto is of type bytes."""
     instance_settings = definitions.AgentSettings(

--- a/tests/runtimes/local/agent_runtime_test.py
+++ b/tests/runtimes/local/agent_runtime_test.py
@@ -412,3 +412,65 @@ def testCreateAgentService_whenServiceNameProvidedInAgentSettings_overridesAgent
 
     kwargs = create_service_mock.call_args.kwargs
     assert kwargs["name"] == "crawler_bus"
+
+
+def testCreateAgentService_whenImageNameTooLongForRandomSuffix_serviceNameTruncatedToFitSuffix(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """When the base service name is too long to append a random suffix, the base is truncated so the suffix always fits."""
+    agent_def = agent_definitions.AgentDefinition(
+        name="agent_name_from_def",
+        mounts=[],
+        mem_limit=None,
+        restart_policy="",
+        open_ports=[],
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_agent_definition_from_label",
+        return_value=agent_def,
+    )
+    mocker.patch.object(
+        ostorlab.runtimes.definitions.AgentSettings,
+        "container_image",
+        property(lambda name: "a" * 70 + ":latest"),
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.update_agent_settings",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_settings_config",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_definition_config",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.random.randrange", return_value=1234
+    )
+    create_service_mock = mocker.patch(
+        "docker.models.services.ServiceCollection.create", return_value=None
+    )
+
+    docker_client = docker.from_env()
+    agent_settings = definitions.AgentSettings(
+        key="agent/ostorlab/test",
+        restart_policy="on-failure",
+        constraints=[],
+        mounts=[],
+        open_ports=[],
+    )
+    runtime_agent = agent_runtime.AgentRuntime(
+        agent_settings,
+        "scanner0",
+        docker_client,
+        mq_service=None,
+        redis_service=None,
+        jaeger_service=None,
+    )
+    runtime_agent.create_agent_service(network_name="test", extra_configs=[])
+
+    kwargs = create_service_mock.call_args.kwargs
+    assert len(kwargs["name"]) <= 63
+    assert kwargs["name"].endswith("_1234")

--- a/tests/runtimes/local/agent_runtime_test.py
+++ b/tests/runtimes/local/agent_runtime_test.py
@@ -352,3 +352,63 @@ def testCreateAgentService_whenServiceNameProvidedInAgentDefinitionAndTooLong_ra
         runtime_agent.create_agent_service(network_name="test", extra_configs=[])
 
     assert create_service_mock.call_count == 0
+
+
+def testCreateAgentService_whenServiceNameProvidedInAgentSettings_overridesAgentDefinitionServiceName(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Test that service_name from AgentSettings (YAML) takes precedence over the image label service_name."""
+    agent_def = agent_definitions.AgentDefinition(
+        name="crawler",
+        service_name="crawler",
+        mounts=[],
+        mem_limit=None,
+        restart_policy="",
+        open_ports=[],
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_agent_definition_from_label",
+        return_value=agent_def,
+    )
+    mocker.patch.object(
+        ostorlab.runtimes.definitions.AgentSettings,
+        "container_image",
+        property(container_name_mock),
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.update_agent_settings",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_settings_config",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_definition_config",
+        return_value=None,
+    )
+    create_service_mock = mocker.patch(
+        "docker.models.services.ServiceCollection.create", return_value=None
+    )
+
+    docker_client = docker.from_env()
+    agent_settings = definitions.AgentSettings(
+        key="agent/ostorlab/crawler",
+        service_name="crawler_bus",
+        restart_policy="on-failure",
+        constraints=[],
+        mounts=[],
+        open_ports=[],
+    )
+    runtime_agent = agent_runtime.AgentRuntime(
+        agent_settings,
+        "42",
+        docker_client,
+        mq_service=None,
+        redis_service=None,
+        jaeger_service=None,
+    )
+    runtime_agent.create_agent_service(network_name="test", extra_configs=[])
+
+    kwargs = create_service_mock.call_args.kwargs
+    assert kwargs["name"] == "crawler_bus"


### PR DESCRIPTION
## Issue

In the AI Pentest agent group, agents like Crawler need to run as both an MCP server (used by Auto Exploit) and a standard OXO bus agent (emitting request/response to Threat Intel). The natural solution is two entries in the agent group YAML with different args, but both resolve to the same Docker service name baked into the image label, causing:

```
docker.errors.APIError: 409 Client Error: Conflict ("service crawler already exists")
```

<img width="1559" height="613" alt="image" src="https://github.com/user-attachments/assets/f0704eb3-0618-437f-9f58-b8eaf4a53f7a" />


## Fix

Added a `service_name` field to agent group YAML entries. When set, it overrides the service name from the image label, allowing two entries with the same `key` to run as separate Docker services with independent configs:

```yaml
- key: agent/ostorlab/crawler
  args:
    - name: should_start_mcp_server
      type: boolean
      value: true

- key: agent/ostorlab/crawler
  service_name: crawler_bus
```

<img width="1338" height="386" alt="image" src="https://github.com/user-attachments/assets/b8f6ac5f-1844-4f37-bea8-16fa6842c2c7" />

Fallback always unique: in the auto-generated service name path (no explicit service_name), the random suffix is now always appended — previously it was skipped when the base name was too long, causing collisions between multiple instances of the same agent; the base is now truncated to make room for the suffix instead

**Files changed:** `runtimes/definitions.py`, `runtimes/local/agent_runtime.py`, `runtimes/lite_local/agent_runtime.py`


## Note

Still fixing Cloud runtime.