### PR TITLE
fix: Add `opentelemetry-sdk` version 1.39.1 to dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,6 +85,7 @@ agent =
     redis
     google-cloud-logging
     opentelemetry-distro
+    opentelemetry-sdk==1.39.1
     opentelemetry-exporter-jaeger
     deprecated
     opentelemetry-exporter-gcp-trace


### PR DESCRIPTION
opentelemetry-sdk was updated, causing dependency conflicst, this PR fixes it.