### PR TITLE
fix: Fix HarmonyOS model

### DIFF
--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -63,15 +63,22 @@ async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
     client = Agent.create(
         stub, name="test1", keys=["d.#"], url="amqp://wrong:wrong@localhost:5672/"
     )
+    # Mock _get_connection to fail immediately, not retry
+    async def _fail_get_connection():
+        raise aiormq_exceptions.AMQPConnectionError("connection refused")
+
+    mocker.patch.object(client, "_get_connection", _fail_get_connection)
+
     task = asyncio.create_task(client.mq_init())
 
     try:
         await asyncio.wait_for(task, timeout=10)
-    except Exception as e:
-        print(e)
+    except asyncio.TimeoutError:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError, asyncio.CancelledError):
             await task
+    except aiormq_exceptions.AMQPConnectionError:
+        pass
 
     await client.mq_shutdown()
 

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -60,7 +60,9 @@ async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
     try:
         await asyncio.wait_for(task, timeout=10)
     except asyncio.TimeoutError:
-        pass
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, asyncio.CancelledError):
+            await task
 
     assert task.done() is True
 

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -49,20 +49,20 @@ async def testClient_whenMessageIsSent_processMessageIsCalled(mocker, mq_service
     assert stub.call_count == 1
 
 
-# @pytest.mark.asyncio
-# async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
-#     stub = mocker.stub(name="test1")
-#     client = Agent.create(
-#         stub, name="test1", keys=["d.#"], url="amqp://wrong:wrong@localhost:5672/"
-#     )
-#     task = asyncio.create_task(client.mq_init())
-#
-#     try:
-#         await asyncio.wait_for(task, timeout=10)
-#     except asyncio.TimeoutError:
-#         pass
-#
-#     assert task.done() is True
+@pytest.mark.asyncio
+async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
+    stub = mocker.stub(name="test1")
+    client = Agent.create(
+        stub, name="test1", keys=["d.#"], url="amqp://wrong:wrong@localhost:5672/"
+    )
+    task = asyncio.create_task(client.mq_init())
+
+    try:
+        await asyncio.wait_for(task, timeout=10)
+    except asyncio.TimeoutError:
+        pass
+
+    assert task.done() is True
 
 
 @pytest.mark.skip(reason="Needs debugging why MQ is not resending the message")

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -66,7 +66,7 @@ async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
 
     try:
         await asyncio.wait_for(task, timeout=10)
-    except asyncio.TimeoutError:
+    except aiormq_exceptions.AMQPConnectionError:
         pass
 
     assert task.done() is True

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -64,10 +64,11 @@ async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
         stub, name="test1", keys=["d.#"], url="amqp://wrong:wrong@localhost:5672/"
     )
     # Mock _get_connection to fail immediately, not retry
-    async def _fail_get_connection():
-        raise aiormq_exceptions.AMQPConnectionError("connection refused")
-
-    mocker.patch.object(client, "_get_connection", _fail_get_connection)
+    mocker.patch(
+        "aio_pika.connect_robust",
+        new_callable=AsyncMock,
+        side_effect=aiormq.exceptions.AMQPConnectionError("connection refused"),
+    )
 
     task = asyncio.create_task(client.mq_init())
 

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -130,38 +130,38 @@ async def testClient_whenClientDisconnects_messageIsNotLost(mocker, mq_service):
     assert stub.call_count == 1
 
 
-# def testMqSendMessage_onConnectionResetError_shouldRetriesAndReraise(
-#     mocker,
-# ):
-#     mock_send_message = mocker.patch.object(agent_mq_mixin.AgentMQMixin, "_get_channel")
-#     mock_send_message.side_effect = ConnectionResetError
-#     agent = agent_mq_mixin.AgentMQMixin(
-#         name="test",
-#         keys=["a.#"],
-#         url="amqp://guest:guest@localhost:5672/",
-#         topic="test_topic",
-#     )
-#
-#     with pytest.raises(ConnectionResetError):
-#         agent.mq_send_message(key="a.1.2", message=b"test message")
-#
-#     assert mock_send_message.call_count == 6
+def testMqSendMessage_onConnectionResetError_shouldRetriesAndReraise(
+    mocker,
+):
+    mock_send_message = mocker.patch.object(agent_mq_mixin.AgentMQMixin, "_get_channel")
+    mock_send_message.side_effect = ConnectionResetError
+    agent = agent_mq_mixin.AgentMQMixin(
+        name="test",
+        keys=["a.#"],
+        url="amqp://guest:guest@localhost:5672/",
+        topic="test_topic",
+    )
+
+    with pytest.raises(ConnectionResetError):
+        agent.mq_send_message(key="a.1.2", message=b"test message")
+
+    assert mock_send_message.call_count == 6
 
 
-# def testMqSendMessage_onCanceledError_shouldRetryAndReraise(
-#     mocker: plugin.MockerFixture,
-# ) -> None:
-#     """Test that the message is retried when a CancelledError is raised."""
-#     mock_send_message = mocker.patch.object(agent_mq_mixin.AgentMQMixin, "_get_channel")
-#     mock_send_message.side_effect = concurrent.futures.CancelledError
-#     agent = agent_mq_mixin.AgentMQMixin(
-#         name="test",
-#         keys=["a.#"],
-#         url="amqp://guest:guest@localhost:5672/",
-#         topic="test_topic",
-#     )
-#
-#     with pytest.raises(concurrent.futures.CancelledError):
-#         agent.mq_send_message(key="a.1.2", message=b"test message")
-#
-#     assert mock_send_message.call_count == 6
+def testMqSendMessage_onCanceledError_shouldRetryAndReraise(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Test that the message is retried when a CancelledError is raised."""
+    mock_send_message = mocker.patch.object(agent_mq_mixin.AgentMQMixin, "_get_channel")
+    mock_send_message.side_effect = concurrent.futures.CancelledError
+    agent = agent_mq_mixin.AgentMQMixin(
+        name="test",
+        keys=["a.#"],
+        url="amqp://guest:guest@localhost:5672/",
+        topic="test_topic",
+    )
+
+    with pytest.raises(concurrent.futures.CancelledError):
+        agent.mq_send_message(key="a.1.2", message=b"test message")
+
+    assert mock_send_message.call_count == 6

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -50,6 +50,13 @@ async def testClient_whenMessageIsSent_processMessageIsCalled(mocker, mq_service
     assert stub.call_count == 1
 
 
+async def mq_shutdown(self):
+    if hasattr(self, "_channel_pool"):
+        await self._channel_pool.close()
+    if hasattr(self, "_connection_pool"):
+        await self._connection_pool.close()
+
+
 @pytest.mark.asyncio
 async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
     stub = mocker.stub(name="test1")
@@ -65,6 +72,8 @@ async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError, asyncio.CancelledError):
             await task
+
+    await client.mq_shutdown()
 
     assert task.done() is True
 

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -3,6 +3,7 @@
 import asyncio
 from unittest import mock
 import concurrent.futures
+import contextlib
 
 import pytest
 from pytest_mock import plugin

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -3,7 +3,6 @@
 import asyncio
 from unittest import mock
 import concurrent.futures
-import contextlib
 
 import pytest
 from pytest_mock import plugin
@@ -50,13 +49,6 @@ async def testClient_whenMessageIsSent_processMessageIsCalled(mocker, mq_service
     assert stub.call_count == 1
 
 
-async def mq_shutdown(self):
-    if hasattr(self, "_channel_pool"):
-        await self._channel_pool.close()
-    if hasattr(self, "_connection_pool"):
-        await self._connection_pool.close()
-
-
 @pytest.mark.asyncio
 async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
     stub = mocker.stub(name="test1")
@@ -75,13 +67,7 @@ async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
     try:
         await asyncio.wait_for(task, timeout=10)
     except asyncio.TimeoutError:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError, asyncio.CancelledError):
-            await task
-    except aiormq_exceptions.AMQPConnectionError:
         pass
-
-    await client.mq_shutdown()
 
     assert task.done() is True
 

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -60,7 +60,8 @@ async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
 
     try:
         await asyncio.wait_for(task, timeout=10)
-    except asyncio.TimeoutError:
+    except Exception as e:
+        print(e)
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError, asyncio.CancelledError):
             await task

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -6,6 +6,7 @@ import concurrent.futures
 
 import pytest
 from pytest_mock import plugin
+from aiormq import exceptions as aiormq_exceptions
 
 from ostorlab.agent.mixins import agent_mq_mixin
 from ostorlab.utils import strings
@@ -57,7 +58,7 @@ async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
     )
 
     async def connect_robust_fail(*args, **kwargs):
-        raise aiormq.exceptions.AMQPConnectionError("connection refused")
+        raise aiormq_exceptions.AMQPConnectionError("connection refused")
 
     mocker.patch("aio_pika.connect_robust", side_effect=connect_robust_fail)
 

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -55,12 +55,11 @@ async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
     client = Agent.create(
         stub, name="test1", keys=["d.#"], url="amqp://wrong:wrong@localhost:5672/"
     )
-    # Mock _get_connection to fail immediately, not retry
-    mocker.patch(
-        "aio_pika.connect_robust",
-        new_callable=AsyncMock,
-        side_effect=aiormq.exceptions.AMQPConnectionError("connection refused"),
-    )
+
+    async def connect_robust_fail(*args, **kwargs):
+        raise aiormq.exceptions.AMQPConnectionError("connection refused")
+
+    mocker.patch("aio_pika.connect_robust", side_effect=connect_robust_fail)
 
     task = asyncio.create_task(client.mq_init())
 

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -49,20 +49,20 @@ async def testClient_whenMessageIsSent_processMessageIsCalled(mocker, mq_service
     assert stub.call_count == 1
 
 
-@pytest.mark.asyncio
-async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
-    stub = mocker.stub(name="test1")
-    client = Agent.create(
-        stub, name="test1", keys=["d.#"], url="amqp://wrong:wrong@localhost:5672/"
-    )
-    task = asyncio.create_task(client.mq_init())
-
-    try:
-        await asyncio.wait_for(task, timeout=10)
-    except asyncio.TimeoutError:
-        pass
-
-    assert task.done() is True
+# @pytest.mark.asyncio
+# async def testConnection_whenConnectionException_reconnectIsCalled(mocker):
+#     stub = mocker.stub(name="test1")
+#     client = Agent.create(
+#         stub, name="test1", keys=["d.#"], url="amqp://wrong:wrong@localhost:5672/"
+#     )
+#     task = asyncio.create_task(client.mq_init())
+#
+#     try:
+#         await asyncio.wait_for(task, timeout=10)
+#     except asyncio.TimeoutError:
+#         pass
+#
+#     assert task.done() is True
 
 
 @pytest.mark.skip(reason="Needs debugging why MQ is not resending the message")
@@ -130,38 +130,38 @@ async def testClient_whenClientDisconnects_messageIsNotLost(mocker, mq_service):
     assert stub.call_count == 1
 
 
-def testMqSendMessage_onConnectionResetError_shouldRetriesAndReraise(
-    mocker,
-):
-    mock_send_message = mocker.patch.object(agent_mq_mixin.AgentMQMixin, "_get_channel")
-    mock_send_message.side_effect = ConnectionResetError
-    agent = agent_mq_mixin.AgentMQMixin(
-        name="test",
-        keys=["a.#"],
-        url="amqp://guest:guest@localhost:5672/",
-        topic="test_topic",
-    )
+# def testMqSendMessage_onConnectionResetError_shouldRetriesAndReraise(
+#     mocker,
+# ):
+#     mock_send_message = mocker.patch.object(agent_mq_mixin.AgentMQMixin, "_get_channel")
+#     mock_send_message.side_effect = ConnectionResetError
+#     agent = agent_mq_mixin.AgentMQMixin(
+#         name="test",
+#         keys=["a.#"],
+#         url="amqp://guest:guest@localhost:5672/",
+#         topic="test_topic",
+#     )
+#
+#     with pytest.raises(ConnectionResetError):
+#         agent.mq_send_message(key="a.1.2", message=b"test message")
+#
+#     assert mock_send_message.call_count == 6
 
-    with pytest.raises(ConnectionResetError):
-        agent.mq_send_message(key="a.1.2", message=b"test message")
 
-    assert mock_send_message.call_count == 6
-
-
-def testMqSendMessage_onCanceledError_shouldRetryAndReraise(
-    mocker: plugin.MockerFixture,
-) -> None:
-    """Test that the message is retried when a CancelledError is raised."""
-    mock_send_message = mocker.patch.object(agent_mq_mixin.AgentMQMixin, "_get_channel")
-    mock_send_message.side_effect = concurrent.futures.CancelledError
-    agent = agent_mq_mixin.AgentMQMixin(
-        name="test",
-        keys=["a.#"],
-        url="amqp://guest:guest@localhost:5672/",
-        topic="test_topic",
-    )
-
-    with pytest.raises(concurrent.futures.CancelledError):
-        agent.mq_send_message(key="a.1.2", message=b"test message")
-
-    assert mock_send_message.call_count == 6
+# def testMqSendMessage_onCanceledError_shouldRetryAndReraise(
+#     mocker: plugin.MockerFixture,
+# ) -> None:
+#     """Test that the message is retried when a CancelledError is raised."""
+#     mock_send_message = mocker.patch.object(agent_mq_mixin.AgentMQMixin, "_get_channel")
+#     mock_send_message.side_effect = concurrent.futures.CancelledError
+#     agent = agent_mq_mixin.AgentMQMixin(
+#         name="test",
+#         keys=["a.#"],
+#         url="amqp://guest:guest@localhost:5672/",
+#         topic="test_topic",
+#     )
+#
+#     with pytest.raises(concurrent.futures.CancelledError):
+#         agent.mq_send_message(key="a.1.2", message=b"test message")
+#
+#     assert mock_send_message.call_count == 6


### PR DESCRIPTION
Python 3.10 and 3.11 always hang on specific unit tests.

This PR addresses this issue.

