### PR TITLE
fix: Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 # OXO Scan Orchestration Engine
 
-OXO is a security scanning framework built for modularity, scalability and simplicity.
+OXO is a security scanning framework built for modularity, scalability, and simplicity.
 
-OXO Engine combines specialized tools to work cohesively to find vulnerabilities and perform actions like recon, enumeration, fingerprinting ...
+OXO Engine combines specialized tools to work cohesively to find vulnerabilities and perform actions like recon, enumeration, and fingerprinting.
 
 
 * [Documentation](https://oxo.ostorlab.co/docs)
@@ -19,12 +19,12 @@ OXO Engine combines specialized tools to work cohesively to find vulnerabilities
 
 # Requirements
 
-Docker is required to run scans locally. To install docker, please follow these
+Docker is required to run scans locally. To install Docker, please follow these
 [instructions](https://docs.docker.com/get-docker/).
 
 # Installing
 
-OXO ships as a Python package on pypi. To install it, simply run the following command if you have `pip` already
+OXO ships as a Python package on PyPI. To install it, simply run the following command if you have `pip` already
 installed.
 
 ```shell
@@ -33,10 +33,9 @@ pip install -U ostorlab
 
 # Getting Started
 
-OXO ships with a store that boasts dozens of agents, from network scanning agents like nmap, nuclei or
-tsunami,
-web scanner like Zap, web fingerprinting tools like Whatweb and Wappalyzer, DNS brute forcing like Subfinder and Dnsx,
-malware file scanning like Virustotal and much more.
+OXO ships with a store that boasts dozens of agents, from network scanning agents like Nmap, Nuclei, or Tsunami,
+web scanners like ZAP, web fingerprinting tools like WhatWeb and Wappalyzer, DNS brute-forcing tools like Subfinder and Dnsx,
+malware file scanning like VirusTotal, and much more.
 
 To run any of these tools combined, simply run the following command:
 
@@ -59,9 +58,9 @@ This command will download and install the following scanning agents:
 * [agent/ostorlab/tsunami](https://oxo.ostorlab.co/store/agent/ostorlab/tsunami)
 * [agent/ostorlab/nuclei](https://oxo.ostorlab.co/store/agent/ostorlab/nuclei)
 
-And will scan the target IP address `8.8.8.8`.
+It will scan the target IP address `8.8.8.8`.
 
-Agents are shipped as standard docker images.
+Agents are shipped as standard Docker images.
 
 To check the scan status, run:
 
@@ -85,22 +84,22 @@ docker run -v /var/run/docker.sock:/var/run/docker.sock ostorlab/oxo:latest scan
 
 Notes:
 * The command starts directly with: `scan run`, this is because the `ostorlab/oxo` image has `oxo` as an `entrypoint`.
-* It is important to mount the docker socket so `oxo` can create the agent in the host machine.
+* It is important to mount the Docker socket so OXO can create agents on the host machine.
 
 # Assets
 
-OXO supports scanning of multiple asset types, below is the list of currently supported:
+OXO supports scanning multiple asset types; below is the list of currently supported:
 
 | Asset       | Description                                                                        |
 |-------------|------------------------------------------------------------------------------------|
-| agent       | Run scan for agent. This is used for agents scanning themselves (meta-scanning :). |
-| ip          | Run scan for IP address or an IP range .                                           |
-| link        | Run scan for web link accepting a URL, method, headers and request body.           |
-| file        | Run scan for a generic file.                                                       |
-| android-aab | Run scan for an Android .AAB package file.                                         |
-| android-apk | Run scan for an Android .APK package file.                                         |
-| ios-ipa     | Run scan for iOS .IPA file.                                                        |
-| domain-name | Run scan for Domain Name asset with specifying protocol or port.                   |
+| agent       | Run a scan for an agent. This is used for agents scanning themselves (meta-scanning).|
+| ip          | Run a scan for an IP address or an IP range.                                       |
+| link        | Run a scan for a web link, accepting a URL, method, headers, and request body.     |
+| file        | Run a scan for a generic file.                                                     |
+| android-aab | Run a scan for an Android .AAB package file.                                       |
+| android-apk | Run a scan for an Android .APK package file.                                       |
+| ios-ipa     | Run a scan for an iOS .IPA file.                                                   |
+| domain-name | Run a scan for a domain name asset by specifying the protocol or port.             |
 
 # The Store
 
@@ -109,39 +108,39 @@ OXO lists all agents on a public store where you can search and also publish you
 ![Store](images/store-preview.gif)
 
 
-# Publish your first Agent
+# Publish Your First Agent
 
 To write your first agent, you can check out a full
 tutorial [here](https://oxo.ostorlab.co/tutorials/write_an_agent).
 
-The steps are basically the following:
+The steps are basically as follows:
 
-* Clone a template agent with all files already setup.
+* Clone a template agent with all files already set up.
 * Change the `template_agent.py` file to add your logic.
-* Change the `Dockerfile` adding any extra building steps.
-* Change the `ostorlab.yaml` adding selectors, documentation, image, license.
-* Publish on the store.
+* Change the `Dockerfile` by adding any extra building steps.
+* Change the `ostorlab.yaml` by adding selectors, documentation, image, and license.
+* Publish it on the store.
 * Profit!
 
 Once you have written your agent, you can publish it on the store for others to use and discover it. The store
-will handle agent building and will automatically pick up new releases from your git repo.
+will handle agent building and will automatically pick up new releases from your Git repo.
 
 ![Build](images/build.gif)
 
-## Ideas for Agents to build
+## Ideas for Agents to Build
 
-Implementation of popular tools like:
+Implementations of popular tools such as:
 
 * ~~[semgrep](https://github.com/returntocorp/semgrep) for source code scanning.~~
-* [nbtscan](http://www.unixwiz.net/tools/nbtscan.html): Scans for open NETBIOS nameservers on your target’s network.
+* [nbtscan](http://www.unixwiz.net/tools/nbtscan.html): Scans for open NetBIOS name servers on your target’s network.
 * [onesixtyone](https://github.com/trailofbits/onesixtyone): Fast scanner to find publicly exposed SNMP services.
 * [Retire.js](http://retirejs.github.io/retire.js/): Scanner detecting the use of JavaScript libraries with known
   vulnerabilities.
 * ~~[snallygaster](https://github.com/hannob/snallygaster): Finds file leaks and other security problems on HTTP servers.~~
-* [testssl.sh](https://testssl.sh/): Identify various TLS/SSL weaknesses, including Heartbleed, CRIME and ROBOT.
-* ~~[TruffleHog](https://github.com/trufflesecurity/truffleHog): Searches through git repositories for high entropy~~
+* [testssl.sh](https://testssl.sh/): Identifies various TLS/SSL weaknesses, including Heartbleed, CRIME, and ROBOT.
+* ~~[TruffleHog](https://github.com/trufflesecurity/truffleHog): Searches through Git repositories for high-entropy~~
   strings and secrets, digging deep into commit history.
-* [cve-bin-tool](https://github.com/intel/cve-bin-tool): Scan binaries for vulnerable components.
+* [cve-bin-tool](https://github.com/intel/cve-bin-tool): Scans binaries for vulnerable components.
 * [XSStrike](https://github.com/s0md3v/XSStrike): XSS web vulnerability scanner with generative payload.
 * ~~[Subjack](https://github.com/haccer/subjack): Subdomain takeover scanning tool.~~
 * [DnsReaper](https://github.com/punk-security/dnsReaper): Subdomain takeover scanning tool.


### PR DESCRIPTION
## Summary
Fix typos and grammatical errors in README.md to improve readability and professionalism.

## Changes
- Fixed punctuation and grammatical errors (e.g., Oxford commas, sentence structure).
- Corrected capitalization of tool names and technologies (Nmap, Nuclei, ZAP, Docker, Git, PyPI).
- Improved clarity in the Assets table and the Getting Started section.
- Fixed minor formatting issues.

Fixes ticket 481807