### PR TITLE
feature: Use list on repeated objects

### DIFF
--- a/src/ostorlab/runtimes/definitions.py
+++ b/src/ostorlab/runtimes/definitions.py
@@ -273,11 +273,11 @@ class AgentGroupDefinition:
                 version=agent.version,
                 args=agent_args,
                 replicas=replicas,
-                caps=agent.caps,
+                caps=list(agent.caps),
                 cyclic_processing_limit=agent.cyclic_processing_limit,
                 depth_processing_limit=agent.depth_processing_limit,
-                accepted_agents=agent.accepted_agents,
-                in_selectors=agent.in_selectors,
+                accepted_agents=list(agent.accepted_agents),
+                in_selectors=list(agent.in_selectors),
             )
 
             agent_settings.append(agent_def)

--- a/tests/runtimes/definitions_test.py
+++ b/tests/runtimes/definitions_test.py
@@ -416,6 +416,36 @@ def testAgentInstanceSettingsToRawProto_whenServiceNameIsNotSet_shouldDeserializ
     assert parsed_proto.service_name is None
 
 
+def testAgentGroupDefinitionFromNatsRequest_whenAgentHasCapsAndSelectors_returnsNativePythonLists() -> (
+    None
+):
+    """Ensure caps, accepted_agents, and in_selectors are plain Python lists, not protobuf RepeatedScalarFieldContainers."""
+    msg = startAgentScan_pb2.Message(
+        reference_scan_id=42,
+        key="agentgroup/ostorlab/agent_group42",
+        agents=[
+            startAgentScan_pb2.Agent(
+                key="agent/ostorlab/agent1",
+                caps=["NET_ADMIN", "SYS_PTRACE"],
+                accepted_agents=["agent/ostorlab/agent2"],
+                in_selectors=["v3.report.vulnerability.network.port.service.http"],
+            ),
+        ],
+        apk=apk_pb2.Message(content=b"dummy_apk"),
+    )
+
+    agent_group_def = definitions.AgentGroupDefinition.from_bus_message(msg)
+
+    assert isinstance(agent_group_def.agents[0].caps, list) is True
+    assert isinstance(agent_group_def.agents[0].accepted_agents, list) is True
+    assert isinstance(agent_group_def.agents[0].in_selectors, list) is True
+    assert agent_group_def.agents[0].caps == ["NET_ADMIN", "SYS_PTRACE"]
+    assert agent_group_def.agents[0].accepted_agents == ["agent/ostorlab/agent2"]
+    assert agent_group_def.agents[0].in_selectors == [
+        "v3.report.vulnerability.network.port.service.http"
+    ]
+
+
 def testAssetGroupDefinitionFromYaml_whenYamlIsValid_returnsValidAssetGroupDefinition(
     mocker: plugin.MockerFixture,
 ):


### PR DESCRIPTION
## Fix from_bus_message passing protobuf repeated fields directly to Docker SDK
                                                                                                                                                                                        
  AgentGroupDefinition.from_bus_message was passing caps, accepted_agents, and in_selectors as RepeatedScalarFieldContainer (protobuf's type for repeated string fields) directly into  
  AgentSettings. Docker SDK's services.create enforces a strict isinstance(cap_add, list) check, causing a TypeError crash before any agent service could start.                        
                                                                                                                                                                                        
  This only affects on-prem scanners using the ostorlab scanner CLI — the Contabo path goes through from_yaml which returns native Python lists already.

## Before
<img width="1332" height="388" alt="image" src="https://github.com/user-attachments/assets/30ab6929-7a1b-4944-bc93-6fd51cabfce8" />

<img width="924" height="314" alt="image" src="https://github.com/user-attachments/assets/15eaf779-9e02-4a83-b15e-a7176ec6a4e4" />

## After

<img width="704" height="594" alt="image" src="https://github.com/user-attachments/assets/f2cba267-c7d5-4adf-a450-1b75de5b3242" />

