### PR TITLE
feature: set service name env var in agent containers

### DIFF
--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -50,7 +50,11 @@ class MaximumDepthProcessReachedError(exceptions.OstorlabError):
 
 
 def _setup_logging(
-    hostname: str, agent_key: str, agent_version: str, universe: str
+    hostname: str,
+    agent_key: str,
+    agent_version: str,
+    universe: str,
+    service_name: str | None = None,
 ) -> None:
     gcp_logging_credential = os.environ.get(GCP_LOGGING_CREDENTIAL_ENV)
     if gcp_logging_credential is not None:
@@ -63,14 +67,15 @@ def _setup_logging(
             )
             credentials = service_account.Credentials.from_service_account_info(info)
             client = google.cloud.logging.Client(credentials=credentials)
-            client.setup_logging(
-                labels={
-                    "agent_key": agent_key,
-                    "agent_version": agent_version,
-                    "universe": universe,
-                    "hostname": hostname,
-                }
-            )
+            labels = {
+                "agent_key": agent_key,
+                "agent_version": agent_version,
+                "universe": universe,
+                "hostname": hostname,
+            }
+            if service_name is not None:
+                labels["service_name"] = service_name
+            client.setup_logging(labels=labels)
         except ImportError:
             logger.error(
                 "Could not import Google Cloud Logging, install it with `pip install 'ostorlab[google-cloud-logging]'"
@@ -491,6 +496,7 @@ class AgentMixin(
                 agent_key=agent_settings.key,
                 agent_version=agent_definition.version or "latest",
                 universe=os.environ.get("UNIVERSE"),
+                service_name=os.getenv("SERVICE_NAME"),
             )
 
             instance = cls(

--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -54,7 +54,7 @@ def _setup_logging(
     agent_key: str,
     agent_version: str,
     universe: str,
-    service_name: str | None = None,
+service_name: Optional[str] = None
 ) -> None:
     gcp_logging_credential = os.environ.get(GCP_LOGGING_CREDENTIAL_ENV)
     if gcp_logging_credential is not None:

--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -54,7 +54,7 @@ def _setup_logging(
     agent_key: str,
     agent_version: str,
     universe: str,
-service_name: Optional[str] = None
+    service_name: Optional[str] = None,
 ) -> None:
     gcp_logging_credential = os.environ.get(GCP_LOGGING_CREDENTIAL_ENV)
     if gcp_logging_credential is not None:

--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -496,7 +496,7 @@ class AgentMixin(
                 agent_key=agent_settings.key,
                 agent_version=agent_definition.version or "latest",
                 universe=os.environ.get("UNIVERSE"),
-                service_name=os.getenv("SERVICE_NAME"),
+                service_name=os.environ.get("SERVICE_NAME"),
             )
 
             instance = cls(

--- a/src/ostorlab/runtimes/lite_local/agent_runtime.py
+++ b/src/ostorlab/runtimes/lite_local/agent_runtime.py
@@ -386,6 +386,7 @@ class AgentRuntime:
 
         env = [
             f"UNIVERSE={self.runtime_name}",
+            f"SERVICE_NAME={docker_service_name}",
         ]
         if self._gcp_logging_credential is not None:
             env.append(

--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -375,6 +375,7 @@ class AgentRuntime:
 
         env = [
             f"UNIVERSE={self.runtime_name}",
+            f"SERVICE_NAME={docker_service_name}",
         ]
         if self._gcp_logging_credential is not None:
             env.append(

--- a/tests/agent/agent_test.py
+++ b/tests/agent/agent_test.py
@@ -1,5 +1,6 @@
 """Agent class unit tests."""
 
+import base64
 import datetime
 import json
 import logging
@@ -1071,3 +1072,56 @@ def testEmit_whenOutSelectorIsNotParent_dontEmitMessage(
                 "risk_rating": "MEDIUM",
             },
         )
+
+
+def testSetupLogging_whenServiceNameIsProvided_labelIncludesServiceName(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """service_name must appear in GCP logging labels when set."""
+    mock_client_instance = mocker.MagicMock()
+    mocker.patch("google.cloud.logging.Client", return_value=mock_client_instance)
+    mocker.patch(
+        "google.oauth2.service_account.Credentials.from_service_account_info",
+        return_value=mocker.MagicMock(),
+    )
+    fake_cred = base64.b64encode(
+        json.dumps({"type": "service_account"}).encode()
+    ).decode()
+    mocker.patch.dict("os.environ", {"GCP_LOGGING_CREDENTIAL": fake_cred})
+
+    agent._setup_logging(
+        hostname="host1",
+        agent_key="agent/org/test",
+        agent_version="1.0",
+        universe="universe42",
+        service_name="my_swarm_service",
+    )
+
+    labels = mock_client_instance.setup_logging.call_args.kwargs["labels"]
+    assert labels["service_name"] == "my_swarm_service"
+
+
+def testSetupLogging_whenServiceNameIsNotProvided_labelDoesNotIncludeServiceName(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """service_name label must be absent when not set."""
+    mock_client_instance = mocker.MagicMock()
+    mocker.patch("google.cloud.logging.Client", return_value=mock_client_instance)
+    mocker.patch(
+        "google.oauth2.service_account.Credentials.from_service_account_info",
+        return_value=mocker.MagicMock(),
+    )
+    fake_cred = base64.b64encode(
+        json.dumps({"type": "service_account"}).encode()
+    ).decode()
+    mocker.patch.dict("os.environ", {"GCP_LOGGING_CREDENTIAL": fake_cred})
+
+    agent._setup_logging(
+        hostname="host1",
+        agent_key="agent/org/test",
+        agent_version="1.0",
+        universe="universe42",
+    )
+
+    labels = mock_client_instance.setup_logging.call_args.kwargs["labels"]
+    assert "service_name" not in labels

--- a/tests/runtimes/lite_local/runtime_test.py
+++ b/tests/runtimes/lite_local/runtime_test.py
@@ -328,3 +328,59 @@ def testLiteLocalCreateAgentService_whenReplicasProvided_serviceCreatedWithRepli
 
     kwargs = create_service_mock.call_args.kwargs
     assert kwargs["mode"] == {"replicated": {"Replicas": 3}}
+
+
+def testLiteLocalCreateAgentService_whenServiceNameIsSet_serviceNameInjectedAsEnvVar(
+    mocker,
+) -> None:
+    """SERVICE_NAME env var must equal the docker service name so agents can label GCP logs."""
+    agent_def = agent_definitions.AgentDefinition(
+        name="agent_name_from_def",
+        service_name="my_explicit_service",
+        mounts=[],
+        mem_limit=420000,
+        restart_policy="",
+    )
+    mocker.patch(
+        "ostorlab.runtimes.lite_local.agent_runtime.AgentRuntime.create_agent_definition_from_label",
+        return_value=agent_def,
+    )
+    mocker.patch.object(
+        ostorlab.runtimes.definitions.AgentSettings,
+        "container_image",
+        property(container_name_mock),
+    )
+    mocker.patch(
+        "ostorlab.runtimes.lite_local.agent_runtime.AgentRuntime.update_agent_settings",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.lite_local.agent_runtime.AgentRuntime.create_settings_config",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.lite_local.agent_runtime.AgentRuntime.create_definition_config",
+        return_value=None,
+    )
+    create_service_mock = mocker.patch(
+        "docker.models.services.ServiceCollection.create", return_value=None
+    )
+
+    docker_client = docker.from_env()
+    agent_settings = definitions.AgentSettings(key="agent/org/name")
+    runtime_agent = agent_runtime.AgentRuntime(
+        agent_settings,
+        "42",
+        docker_client,
+        bus_url="bus",
+        bus_vhost="/",
+        bus_management_url="mgmt",
+        bus_exchange_topic="topic",
+        redis_url="redis://redis",
+        tracing_collector_url="jaeger://localhost/",
+    )
+    runtime_agent.create_agent_service(network_name="test", extra_configs=[])
+
+    kwargs = create_service_mock.call_args.kwargs
+    service_name = kwargs["name"]
+    assert f"SERVICE_NAME={service_name}" in kwargs["env"]

--- a/tests/runtimes/lite_local/runtime_test.py
+++ b/tests/runtimes/lite_local/runtime_test.py
@@ -362,11 +362,7 @@ def testLiteLocalCreateAgentService_whenServiceNameIsSet_serviceNameInjectedAsEn
         "ostorlab.runtimes.lite_local.agent_runtime.AgentRuntime.create_definition_config",
         return_value=None,
     )
-    create_service_mock = mocker.patch(
-        "docker.models.services.ServiceCollection.create", return_value=None
-    )
-
-    docker_client = docker.from_env()
+    docker_client = mocker.MagicMock()
     agent_settings = definitions.AgentSettings(key="agent/org/name")
     runtime_agent = agent_runtime.AgentRuntime(
         agent_settings,
@@ -381,6 +377,6 @@ def testLiteLocalCreateAgentService_whenServiceNameIsSet_serviceNameInjectedAsEn
     )
     runtime_agent.create_agent_service(network_name="test", extra_configs=[])
 
-    kwargs = create_service_mock.call_args.kwargs
+    kwargs = docker_client.services.create.call_args.kwargs
     service_name = kwargs["name"]
     assert f"SERVICE_NAME={service_name}" in kwargs["env"]

--- a/tests/runtimes/local/agent_runtime_test.py
+++ b/tests/runtimes/local/agent_runtime_test.py
@@ -582,3 +582,57 @@ def testCreateAgentService_whenImageNameTooLongForRandomSuffix_serviceNameTrunca
     kwargs = create_service_mock.call_args.kwargs
     assert len(kwargs["name"]) <= 63
     assert kwargs["name"].endswith("_1234")
+
+
+def testCreateAgentService_whenServiceNameIsSet_serviceNameInjectedAsEnvVar(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """SERVICE_NAME env var must equal the docker service name so agents can label GCP logs."""
+    agent_def = agent_definitions.AgentDefinition(
+        name="agent_name_from_def",
+        service_name="my_explicit_service",
+        mounts=[],
+        mem_limit=420000,
+        restart_policy="",
+        open_ports=[],
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_agent_definition_from_label",
+        return_value=agent_def,
+    )
+    mocker.patch.object(
+        ostorlab.runtimes.definitions.AgentSettings,
+        "container_image",
+        property(container_name_mock),
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.update_agent_settings",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_settings_config",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_definition_config",
+        return_value=None,
+    )
+    create_service_mock = mocker.patch(
+        "docker.models.services.ServiceCollection.create", return_value=None
+    )
+
+    docker_client = docker.from_env()
+    agent_settings = definitions.AgentSettings(key="agent/org/name")
+    runtime_agent = agent_runtime.AgentRuntime(
+        agent_settings,
+        "42",
+        docker_client,
+        mq_service=None,
+        redis_service=None,
+        jaeger_service=None,
+    )
+    runtime_agent.create_agent_service(network_name="test", extra_configs=[])
+
+    kwargs = create_service_mock.call_args.kwargs
+    service_name = kwargs["name"]
+    assert f"SERVICE_NAME={service_name}" in kwargs["env"]

--- a/tests/runtimes/local/agent_runtime_test.py
+++ b/tests/runtimes/local/agent_runtime_test.py
@@ -617,11 +617,8 @@ def testCreateAgentService_whenServiceNameIsSet_serviceNameInjectedAsEnvVar(
         "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_definition_config",
         return_value=None,
     )
-    create_service_mock = mocker.patch(
-        "docker.models.services.ServiceCollection.create", return_value=None
-    )
 
-    docker_client = docker.from_env()
+    docker_client = mocker.MagicMock()
     agent_settings = definitions.AgentSettings(key="agent/org/name")
     runtime_agent = agent_runtime.AgentRuntime(
         agent_settings,
@@ -633,6 +630,6 @@ def testCreateAgentService_whenServiceNameIsSet_serviceNameInjectedAsEnvVar(
     )
     runtime_agent.create_agent_service(network_name="test", extra_configs=[])
 
-    kwargs = create_service_mock.call_args.kwargs
+    kwargs = docker_client.services.create.call_args.kwargs
     service_name = kwargs["name"]
     assert f"SERVICE_NAME={service_name}" in kwargs["env"]


### PR DESCRIPTION
This PR sets the agent service name in the container's environment, making it available inside the OXO agent for logging purposes.