### PR TITLE
feature: Feature/adding disk usage scanning status

### DIFF
--- a/src/ostorlab/apis/add_scanner_state.py
+++ b/src/ostorlab/apis/add_scanner_state.py
@@ -59,6 +59,7 @@ class AddScannerStateAPIRequest(request.APIRequest):
                         "cpuLoad": self._state.cpu_load,
                         "totalCpu": self._state.total_cpu,
                         "diskUsage": self._state.disk_usage,
+                        "totalDisk": self._state.total_disk,
                     }
                 }
             ),

--- a/src/ostorlab/apis/add_scanner_state.py
+++ b/src/ostorlab/apis/add_scanner_state.py
@@ -58,6 +58,7 @@ class AddScannerStateAPIRequest(request.APIRequest):
                         "totalMemory": self._state.total_memory,
                         "cpuLoad": self._state.cpu_load,
                         "totalCpu": self._state.total_cpu,
+                        "diskUsage": self._state.disk_usage,
                     }
                 }
             ),

--- a/src/ostorlab/utils/definitions.py
+++ b/src/ostorlab/utils/definitions.py
@@ -98,3 +98,4 @@ class ScannerState:
     hostname: str
     ip: str
     disk_usage: float = 0.0
+    total_disk: int = 0

--- a/src/ostorlab/utils/definitions.py
+++ b/src/ostorlab/utils/definitions.py
@@ -97,3 +97,4 @@ class ScannerState:
     total_memory: int
     hostname: str
     ip: str
+    disk_usage: float = 0.0

--- a/src/ostorlab/utils/scanner_state_reporter.py
+++ b/src/ostorlab/utils/scanner_state_reporter.py
@@ -34,6 +34,7 @@ class ScannerStateReporter:
                 hostname=self._hostname,
                 ip=self._ip,
                 disk_usage=psutil.disk_usage("/").percent,
+                total_disk=psutil.disk_usage("/").total >> 30,  # total disk in GB
             )
         except ImportError:
             state = definitions.ScannerState(

--- a/src/ostorlab/utils/scanner_state_reporter.py
+++ b/src/ostorlab/utils/scanner_state_reporter.py
@@ -33,6 +33,7 @@ class ScannerStateReporter:
                 total_memory=psutil.virtual_memory().total >> 30,  # total memory in GB
                 hostname=self._hostname,
                 ip=self._ip,
+                disk_usage=psutil.disk_usage("/").percent,
             )
         except ImportError:
             state = definitions.ScannerState(

--- a/tests/utils/scanner_state_reporter_test.py
+++ b/tests/utils/scanner_state_reporter_test.py
@@ -12,6 +12,10 @@ class Memory:
     total: int = 33454317568
 
 
+class Disk:
+    percent: float = 50.0
+
+
 @pytest.mark.asyncio
 async def testReportMethod_whenCalled_updateValuesCorrectly(
     mocker: pytest_mock.MockerFixture,
@@ -23,6 +27,7 @@ async def testReportMethod_whenCalled_updateValuesCorrectly(
     mocker.patch("psutil.cpu_percent", return_value=10)
     mocker.patch("psutil.cpu_count", return_value=10)
     mocker.patch("psutil.virtual_memory", return_value=Memory())
+    mocker.patch("psutil.disk_usage", return_value=Disk())
     api_request_mock = mocker.patch(
         "ostorlab.apis.add_scanner_state.AddScannerStateAPIRequest"
     )
@@ -35,6 +40,7 @@ async def testReportMethod_whenCalled_updateValuesCorrectly(
         total_memory=31,
         hostname="",
         ip="",
+        disk_usage=50.0,
     )
     report = scanner_state_reporter.ScannerStateReporter(
         scanner_id="GGBD-DJJD-DKJK-DJDD", hostname="", ip=""

--- a/tests/utils/scanner_state_reporter_test.py
+++ b/tests/utils/scanner_state_reporter_test.py
@@ -14,6 +14,7 @@ class Memory:
 
 class Disk:
     percent: float = 50.0
+    total: int = 107374182400  # 100 GB in bytes
 
 
 @pytest.mark.asyncio
@@ -41,6 +42,7 @@ async def testReportMethod_whenCalled_updateValuesCorrectly(
         hostname="",
         ip="",
         disk_usage=50.0,
+        total_disk=100,
     )
     report = scanner_state_reporter.ScannerStateReporter(
         scanner_id="GGBD-DJJD-DKJK-DJDD", hostname="", ip=""


### PR DESCRIPTION
Add disk usage tracking to scanner state

Added disk_usage field to ScannerState dataclass as a percentage (float, defaults to 0.0)
Added total_disk field to ScannerState dataclass as total disk size in GB (int, defaults to 0)
Populated both fields in ScannerStateReporter._capture_state using psutil.disk_usage("/")
Included diskUsage and totalDisk in the GraphQL mutation variables sent to the backend
Updated the scanner state reporter test to mock psutil.disk_usage and assert the correct values for both fields