### PR TITLE
fix: add ticket_key field to ticket proto message

### DIFF
--- a/src/ostorlab/agent/message/proto/v3/report/ticket/ticket.proto
+++ b/src/ostorlab/agent/message/proto/v3/report/ticket/ticket.proto
@@ -12,4 +12,5 @@ message Message {
   required string title = 2;
   required string description = 3;
   repeated Comments comments = 4;
+  optional string ticket_key = 5;
 }

--- a/src/ostorlab/agent/message/proto/v3/report/ticket/ticket_pb2.py
+++ b/src/ostorlab/agent/message/proto/v3/report/ticket/ticket_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cticket.proto\x12-ostorlab.agent.message.proto.v3.report.ticket\"+\n\x08\x43omments\x12\x0e\n\x06\x61uthor\x18\x01 \x02(\t\x12\x0f\n\x07message\x18\x02 \x02(\t\"\x8b\x01\n\x07Message\x12\x11\n\tticket_id\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x02(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x02(\t\x12I\n\x08\x63omments\x18\x04 \x03(\x0b\x32\x37.ostorlab.agent.message.proto.v3.report.ticket.Comments')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cticket.proto\x12-ostorlab.agent.message.proto.v3.report.ticket\"+\n\x08\x43omments\x12\x0e\n\x06\x61uthor\x18\x01 \x02(\t\x12\x0f\n\x07message\x18\x02 \x02(\t\"\x9f\x01\n\x07Message\x12\x11\n\tticket_id\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x02(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x02(\t\x12I\n\x08\x63omments\x18\x04 \x03(\x0b\x32\x37.ostorlab.agent.message.proto.v3.report.ticket.Comments\x12\x12\n\nticket_key\x18\x05 \x01(\t')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'ticket_pb2', globals())
@@ -23,5 +23,5 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _COMMENTS._serialized_start=63
   _COMMENTS._serialized_end=106
   _MESSAGE._serialized_start=109
-  _MESSAGE._serialized_end=248
+  _MESSAGE._serialized_end=268
 # @@protoc_insertion_point(module_scope)

--- a/tests/agent/message/proto/v3/report/ticket/ticket_pb2_test.py
+++ b/tests/agent/message/proto/v3/report/ticket/ticket_pb2_test.py
@@ -46,3 +46,22 @@ def testComment_whenCreateWithDefaults_shouldHaveCorrectDefaults():
 
     assert comment.author == "test_author"
     assert comment.message == ""
+
+
+def testMessage_whenTicketKeySet_shouldSerializeAndDeserializeCorrectly():
+    msg = ticket_pb2.Message()
+    msg.title = "Test Ticket"
+    msg.description = "Test description."
+    msg.ticket_key = "PROJ-123"
+
+    serialized = msg.SerializeToString()
+    deserialized_msg = ticket_pb2.Message()
+    deserialized_msg.ParseFromString(serialized)
+
+    assert deserialized_msg.ticket_key == "PROJ-123"
+
+
+def testMessage_whenTicketKeyNotSet_shouldDefaultToEmpty():
+    msg = ticket_pb2.Message()
+
+    assert msg.ticket_key == ""


### PR DESCRIPTION
## Summary
- Add optional `ticket_key` string field (tag 5) to the ticket proto `Message`.
- Recompile `ticket_pb2.py`.
- Add tests covering serialize/deserialize and default value for `ticket_key`.
