### PR TITLE
fix: Update repository protobuf schema

### DIFF
--- a/src/ostorlab/agent/message/proto/v3/asset/repository/repository.proto
+++ b/src/ostorlab/agent/message/proto/v3/asset/repository/repository.proto
@@ -3,6 +3,6 @@ syntax = "proto2";
 package ostorlab.agent.message.proto.v3.asset.repository;
 
 message Message {
-  required string origin_url = 1;
-  required string commit_hash = 2;
+  optional string repository_url = 1;
+  optional string commit_hash = 2;
 }

--- a/src/ostorlab/agent/message/proto/v3/asset/repository/repository.proto
+++ b/src/ostorlab/agent/message/proto/v3/asset/repository/repository.proto
@@ -3,8 +3,6 @@ syntax = "proto2";
 package ostorlab.agent.message.proto.v3.asset.repository;
 
 message Message {
-  optional bytes content = 1;
-  optional string content_url = 2;
-  optional string repo_url = 3;
-  optional string commit_hash = 4;
+  optional string origin_url = 1;
+  optional string commit_hash = 2;
 }

--- a/src/ostorlab/agent/message/proto/v3/asset/repository/repository.proto
+++ b/src/ostorlab/agent/message/proto/v3/asset/repository/repository.proto
@@ -3,6 +3,6 @@ syntax = "proto2";
 package ostorlab.agent.message.proto.v3.asset.repository;
 
 message Message {
-  optional string origin_url = 1;
-  optional string commit_hash = 2;
+  required string origin_url = 1;
+  required string commit_hash = 2;
 }

--- a/src/ostorlab/agent/message/proto/v3/asset/repository/repository_pb2.py
+++ b/src/ostorlab/agent/message/proto/v3/asset/repository/repository_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\nAostorlab/agent/message/proto/v3/asset/repository/repository.proto\x12\x30ostorlab.agent.message.proto.v3.asset.repository\"2\n\x07Message\x12\x12\n\norigin_url\x18\x01 \x01(\t\x12\x13\n\x0b\x63ommit_hash\x18\x02 \x01(\t')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\nAostorlab/agent/message/proto/v3/asset/repository/repository.proto\x12\x30ostorlab.agent.message.proto.v3.asset.repository\"2\n\x07Message\x12\x12\n\norigin_url\x18\x01 \x02(\t\x12\x13\n\x0b\x63ommit_hash\x18\x02 \x02(\t')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)

--- a/src/ostorlab/agent/message/proto/v3/asset/repository/repository_pb2.py
+++ b/src/ostorlab/agent/message/proto/v3/asset/repository/repository_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\nAostorlab/agent/message/proto/v3/asset/repository/repository.proto\x12\x30ostorlab.agent.message.proto.v3.asset.repository\"2\n\x07Message\x12\x12\n\norigin_url\x18\x01 \x02(\t\x12\x13\n\x0b\x63ommit_hash\x18\x02 \x02(\t')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\nAostorlab/agent/message/proto/v3/asset/repository/repository.proto\x12\x30ostorlab.agent.message.proto.v3.asset.repository\"6\n\x07Message\x12\x16\n\x0erepository_url\x18\x01 \x01(\t\x12\x13\n\x0b\x63ommit_hash\x18\x02 \x01(\t')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)

--- a/src/ostorlab/agent/message/proto/v3/asset/repository/repository_pb2.py
+++ b/src/ostorlab/agent/message/proto/v3/asset/repository/repository_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\nAostorlab/agent/message/proto/v3/asset/repository/repository.proto\x12\x30ostorlab.agent.message.proto.v3.asset.repository\"V\n\x07Message\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\x0c\x12\x13\n\x0b\x63ontent_url\x18\x02 \x01(\t\x12\x10\n\x08repo_url\x18\x03 \x01(\t\x12\x13\n\x0b\x63ommit_hash\x18\x04 \x01(\t')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\nAostorlab/agent/message/proto/v3/asset/repository/repository.proto\x12\x30ostorlab.agent.message.proto.v3.asset.repository\"2\n\x07Message\x12\x12\n\norigin_url\x18\x01 \x01(\t\x12\x13\n\x0b\x63ommit_hash\x18\x02 \x01(\t')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,5 +32,5 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'ostorlab.agent.message.prot
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
   _globals['_MESSAGE']._serialized_start=119
-  _globals['_MESSAGE']._serialized_end=205
+  _globals['_MESSAGE']._serialized_end=169
 # @@protoc_insertion_point(module_scope)

--- a/src/ostorlab/assets/repository.py
+++ b/src/ostorlab/assets/repository.py
@@ -10,23 +10,31 @@ from ostorlab.assets import asset
 class Repository(asset.Asset):
     """Source code repository target asset."""
 
-    origin_url: str = ""
+    repository_url: str = ""
     commit_hash: str = ""
 
     def __str__(self) -> str:
-        if self.origin_url != "":
+        if self.repository_url != "":
             if self.commit_hash != "":
-                return f"Repository: {self.origin_url}@{self.commit_hash}"
-            return f"Repository: {self.origin_url}"
+                return f"Repository: {self.repository_url}@{self.commit_hash}"
+            return f"Repository: {self.repository_url}"
         return "Repository"
 
     @property
+    def origin_url(self) -> str:
+        return self.repository_url
+
+    @origin_url.setter
+    def origin_url(self, value: str) -> None:
+        self.repository_url = value
+
+    @property
     def repo_url(self) -> str:
-        return self.origin_url
+        return self.repository_url
 
     @repo_url.setter
     def repo_url(self, value: str) -> None:
-        self.origin_url = value
+        self.repository_url = value
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/assets/repository.py
+++ b/src/ostorlab/assets/repository.py
@@ -1,7 +1,6 @@
 """Repository asset."""
 
 import dataclasses
-from typing import Optional
 
 from ostorlab.assets import asset
 
@@ -11,22 +10,22 @@ from ostorlab.assets import asset
 class Repository(asset.Asset):
     """Source code repository target asset."""
 
-    origin_url: Optional[str] = None
-    commit_hash: Optional[str] = None
+    origin_url: str = ""
+    commit_hash: str = ""
 
     def __str__(self) -> str:
-        if self.origin_url is not None:
-            if self.commit_hash is not None:
+        if self.origin_url:
+            if self.commit_hash:
                 return f"Repository: {self.origin_url}@{self.commit_hash}"
             return f"Repository: {self.origin_url}"
         return "Repository"
 
     @property
-    def repo_url(self) -> Optional[str]:
+    def repo_url(self) -> str:
         return self.origin_url
 
     @repo_url.setter
-    def repo_url(self, value: Optional[str]) -> None:
+    def repo_url(self, value: str) -> None:
         self.origin_url = value
 
     @property

--- a/src/ostorlab/assets/repository.py
+++ b/src/ostorlab/assets/repository.py
@@ -14,8 +14,8 @@ class Repository(asset.Asset):
     commit_hash: str = ""
 
     def __str__(self) -> str:
-        if self.origin_url:
-            if self.commit_hash:
+        if self.origin_url != "":
+            if self.commit_hash != "":
                 return f"Repository: {self.origin_url}@{self.commit_hash}"
             return f"Repository: {self.origin_url}"
         return "Repository"

--- a/src/ostorlab/assets/repository.py
+++ b/src/ostorlab/assets/repository.py
@@ -11,19 +11,23 @@ from ostorlab.assets import asset
 class Repository(asset.Asset):
     """Source code repository target asset."""
 
-    content: Optional[bytes] = None
-    content_url: Optional[str] = None
-    repo_url: Optional[str] = None
+    origin_url: Optional[str] = None
     commit_hash: Optional[str] = None
 
     def __str__(self) -> str:
-        if self.repo_url is not None:
+        if self.origin_url is not None:
             if self.commit_hash is not None:
-                return f"Repository: {self.repo_url}@{self.commit_hash}"
-            return f"Repository: {self.repo_url}"
-        if self.content_url is not None:
-            return f"Repository: {self.content_url}"
+                return f"Repository: {self.origin_url}@{self.commit_hash}"
+            return f"Repository: {self.origin_url}"
         return "Repository"
+
+    @property
+    def repo_url(self) -> Optional[str]:
+        return self.origin_url
+
+    @repo_url.setter
+    def repo_url(self, value: Optional[str]) -> None:
+        self.origin_url = value
 
     @property
     def proto_field(self) -> str:

--- a/src/ostorlab/cli/scan/run/assets/repository.py
+++ b/src/ostorlab/cli/scan/run/assets/repository.py
@@ -1,9 +1,8 @@
 """Asset of type repository.
-This module takes care of preparing a source code repository asset before injecting it to the runtime instance."""
+This module prepares a source code repository asset before injecting it to the runtime."""
 
-import io
 import logging
-from typing import Optional, Tuple
+from typing import Optional
 
 import click
 
@@ -17,37 +16,18 @@ logger = logging.getLogger(__name__)
 
 
 @run.run.command(name="repository")
-@click.option("--file", type=click.File(mode="rb"), multiple=True, required=False)
-@click.option("--url", required=False, multiple=True)
-@click.option("--repo-url", required=False)
-@click.option("--commit-hash", required=False)
+@click.option("--origin-url", required=True)
+@click.option("--commit-hash", required=True)
 @click.pass_context
 def repository_cli(
     ctx: click.core.Context,
-    file: Optional[Tuple[io.FileIO]] = None,
-    url: Optional[Tuple[str]] = None,
-    repo_url: Optional[str] = None,
+    origin_url: Optional[str] = None,
     commit_hash: Optional[str] = None,
 ) -> None:
     """Run scan for a source code repository asset."""
-    assets = []
-    if len(file) > 0:
-        for f in file:
-            assets.append(
-                repository_asset.Repository(
-                    origin_url=repo_url, commit_hash=commit_hash
-                )
-            )
-    elif len(url) > 0:
-        for u in url:
-            assets.append(
-                repository_asset.Repository(
-                    origin_url=repo_url, commit_hash=commit_hash
-                )
-            )
-    else:
-        console.error("Command accepts either --file or --url.")
-        raise click.exceptions.Exit(2)
+    assets = [
+        repository_asset.Repository(origin_url=origin_url, commit_hash=commit_hash)
+    ]
 
     logger.debug("scanning assets %s", [str(a) for a in assets])
     runtime = ctx.obj["runtime"]

--- a/src/ostorlab/cli/scan/run/assets/repository.py
+++ b/src/ostorlab/cli/scan/run/assets/repository.py
@@ -34,20 +34,12 @@ def repository_cli(
     if len(file) > 0:
         for f in file:
             assets.append(
-                repository_asset.Repository(
-                    content=f.read(),
-                    repo_url=repo_url,
-                    commit_hash=commit_hash,
-                )
+                repository_asset.Repository(origin_url=repo_url, commit_hash=commit_hash)
             )
     elif len(url) > 0:
         for u in url:
             assets.append(
-                repository_asset.Repository(
-                    content_url=u,
-                    repo_url=repo_url,
-                    commit_hash=commit_hash,
-                )
+                repository_asset.Repository(origin_url=repo_url, commit_hash=commit_hash)
             )
     else:
         console.error("Command accepts either --file or --url.")

--- a/src/ostorlab/cli/scan/run/assets/repository.py
+++ b/src/ostorlab/cli/scan/run/assets/repository.py
@@ -34,12 +34,16 @@ def repository_cli(
     if len(file) > 0:
         for f in file:
             assets.append(
-                repository_asset.Repository(origin_url=repo_url, commit_hash=commit_hash)
+                repository_asset.Repository(
+                    origin_url=repo_url, commit_hash=commit_hash
+                )
             )
     elif len(url) > 0:
         for u in url:
             assets.append(
-                repository_asset.Repository(origin_url=repo_url, commit_hash=commit_hash)
+                repository_asset.Repository(
+                    origin_url=repo_url, commit_hash=commit_hash
+                )
             )
     else:
         console.error("Command accepts either --file or --url.")

--- a/src/ostorlab/cli/scan/run/assets/repository.py
+++ b/src/ostorlab/cli/scan/run/assets/repository.py
@@ -2,7 +2,6 @@
 This module prepares a source code repository asset before injecting it to the runtime."""
 
 import logging
-from typing import Optional
 
 import click
 
@@ -21,8 +20,8 @@ logger = logging.getLogger(__name__)
 @click.pass_context
 def repository_cli(
     ctx: click.core.Context,
-    origin_url: Optional[str] = None,
-    commit_hash: Optional[str] = None,
+    origin_url: str,
+    commit_hash: str,
 ) -> None:
     """Run scan for a source code repository asset."""
     assets = [

--- a/src/ostorlab/cli/scan/run/assets/repository.py
+++ b/src/ostorlab/cli/scan/run/assets/repository.py
@@ -15,17 +15,19 @@ logger = logging.getLogger(__name__)
 
 
 @run.run.command(name="repository")
-@click.option("--origin-url", required=True)
+@click.option("--repository-url", "--origin-url", required=True)
 @click.option("--commit-hash", required=True)
 @click.pass_context
 def repository_cli(
     ctx: click.core.Context,
-    origin_url: str,
+    repository_url: str,
     commit_hash: str,
 ) -> None:
     """Run scan for a source code repository asset."""
     assets = [
-        repository_asset.Repository(origin_url=origin_url, commit_hash=commit_hash)
+        repository_asset.Repository(
+            repository_url=repository_url, commit_hash=commit_hash
+        )
     ]
 
     logger.debug("scanning assets %s", [str(a) for a in assets])

--- a/tests/agent/message/proto/v3/asset/repository/repository_pb2_test.py
+++ b/tests/agent/message/proto/v3/asset/repository/repository_pb2_test.py
@@ -26,7 +26,7 @@ def testCreate_whenEmpty_hasDefaultValues():
     assert message.commit_hash == ""
 
 
-def testSerializeAndDeserialize_whenEmpty_raisesEncodeError():
+def testSerialize_whenEmpty_raisesEncodeError():
     message = repository_pb2.Message()
 
     with pytest.raises(EncodeError):

--- a/tests/agent/message/proto/v3/asset/repository/repository_pb2_test.py
+++ b/tests/agent/message/proto/v3/asset/repository/repository_pb2_test.py
@@ -5,39 +5,21 @@ from ostorlab.agent.message.proto.v3.asset.repository import repository_pb2
 
 def testSerializeAndDeserialize_whenCreatedWithValidData_returnsEquivalentMessage():
     message = repository_pb2.Message()
-    message.content_url = "https://storage.example.com/repo.zip"
-    message.repo_url = "https://github.com/org/repo.git"
+    message.origin_url = "https://github.com/org/repo.git"
     message.commit_hash = "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
 
     serialized = message.SerializeToString()
     deserialized = repository_pb2.Message()
     deserialized.ParseFromString(serialized)
 
-    assert deserialized.content_url == "https://storage.example.com/repo.zip"
-    assert deserialized.repo_url == "https://github.com/org/repo.git"
+    assert deserialized.origin_url == "https://github.com/org/repo.git"
     assert deserialized.commit_hash == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
-
-
-def testSerializeAndDeserialize_whenCreatedWithContentBytes_returnsEquivalentMessage():
-    message = repository_pb2.Message()
-    message.content = b"PK\x03\x04archive_content"
-    message.repo_url = "https://gitlab.com/org/repo.git"
-    message.commit_hash = "b2b20cdbc6551ba359169a3033f193b7f8c1b95e"
-
-    serialized = message.SerializeToString()
-    deserialized = repository_pb2.Message()
-    deserialized.ParseFromString(serialized)
-
-    assert deserialized.content == b"PK\x03\x04archive_content"
-    assert deserialized.repo_url == "https://gitlab.com/org/repo.git"
 
 
 def testCreate_whenEmpty_hasDefaultValues():
     message = repository_pb2.Message()
 
-    assert message.content == b""
-    assert message.content_url == ""
-    assert message.repo_url == ""
+    assert message.origin_url == ""
     assert message.commit_hash == ""
 
 
@@ -48,7 +30,5 @@ def testSerializeAndDeserialize_whenEmpty_returnsEmptyMessage():
     deserialized = repository_pb2.Message()
     deserialized.ParseFromString(serialized)
 
-    assert deserialized.content == b""
-    assert deserialized.content_url == ""
-    assert deserialized.repo_url == ""
+    assert deserialized.origin_url == ""
     assert deserialized.commit_hash == ""

--- a/tests/agent/message/proto/v3/asset/repository/repository_pb2_test.py
+++ b/tests/agent/message/proto/v3/asset/repository/repository_pb2_test.py
@@ -1,33 +1,34 @@
 """Tests for the repository protobuf message definitions and serialization behavior."""
 
-import pytest
-from google.protobuf.message import EncodeError
-
 from ostorlab.agent.message.proto.v3.asset.repository import repository_pb2
 
 
 def testSerializeAndDeserialize_whenCreatedWithValidData_returnsEquivalentMessage():
     message = repository_pb2.Message()
-    message.origin_url = "https://github.com/org/repo.git"
+    message.repository_url = "https://github.com/org/repo.git"
     message.commit_hash = "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
 
     serialized = message.SerializeToString()
     deserialized = repository_pb2.Message()
     deserialized.ParseFromString(serialized)
 
-    assert deserialized.origin_url == "https://github.com/org/repo.git"
+    assert deserialized.repository_url == "https://github.com/org/repo.git"
     assert deserialized.commit_hash == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
 
 
 def testCreate_whenEmpty_hasDefaultValues():
     message = repository_pb2.Message()
 
-    assert message.origin_url == ""
+    assert message.repository_url == ""
     assert message.commit_hash == ""
 
 
-def testSerialize_whenEmpty_raisesEncodeError():
+def testSerializeAndDeserialize_whenEmpty_returnsEmptyMessage():
     message = repository_pb2.Message()
 
-    with pytest.raises(EncodeError):
-        message.SerializeToString()
+    serialized = message.SerializeToString()
+    deserialized = repository_pb2.Message()
+    deserialized.ParseFromString(serialized)
+
+    assert deserialized.repository_url == ""
+    assert deserialized.commit_hash == ""

--- a/tests/agent/message/proto/v3/asset/repository/repository_pb2_test.py
+++ b/tests/agent/message/proto/v3/asset/repository/repository_pb2_test.py
@@ -1,5 +1,8 @@
 """Tests for the repository protobuf message definitions and serialization behavior."""
 
+import pytest
+from google.protobuf.message import EncodeError
+
 from ostorlab.agent.message.proto.v3.asset.repository import repository_pb2
 
 
@@ -23,12 +26,8 @@ def testCreate_whenEmpty_hasDefaultValues():
     assert message.commit_hash == ""
 
 
-def testSerializeAndDeserialize_whenEmpty_returnsEmptyMessage():
+def testSerializeAndDeserialize_whenEmpty_raisesEncodeError():
     message = repository_pb2.Message()
 
-    serialized = message.SerializeToString()
-    deserialized = repository_pb2.Message()
-    deserialized.ParseFromString(serialized)
-
-    assert deserialized.origin_url == ""
-    assert deserialized.commit_hash == ""
+    with pytest.raises(EncodeError):
+        message.SerializeToString()

--- a/tests/assets/repository_test.py
+++ b/tests/assets/repository_test.py
@@ -4,27 +4,25 @@ from ostorlab.agent.message import serializer
 from ostorlab.assets import repository as repository_asset
 
 
-def testToProto_whenContentUrlSet_returnsSerializedBytes():
+def testToProto_whenOriginUrlSet_returnsSerializedBytes():
     raw = repository_asset.Repository(
-        content_url="https://storage.example.com/repo.zip",
-        repo_url="https://github.com/org/repo.git",
+        origin_url="https://github.com/org/repo.git",
         commit_hash="a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
     ).to_proto()
 
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.repository", raw)
-    assert unraw.content_url == "https://storage.example.com/repo.zip"
-    assert unraw.repo_url == "https://github.com/org/repo.git"
+    assert unraw.origin_url == "https://github.com/org/repo.git"
     assert unraw.commit_hash == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
 
 
-def testToProto_whenContentBytesSet_returnsSerializedBytes():
+def testToProto_whenOriginUrlSetAndDifferentCommit_returnsSerializedBytes():
     raw = repository_asset.Repository(
-        content=b"PK\x03\x04archive",
-        repo_url="https://gitlab.com/org/repo.git",
+        origin_url="https://gitlab.com/org/repo.git",
         commit_hash="b2b20cdbc6551ba359169a3033f193b7f8c1b95e",
     ).to_proto()
 
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.repository", raw)
-    assert unraw.content == b"PK\x03\x04archive"
+    assert unraw.origin_url == "https://gitlab.com/org/repo.git"
+    assert unraw.commit_hash == "b2b20cdbc6551ba359169a3033f193b7f8c1b95e"

--- a/tests/assets/repository_test.py
+++ b/tests/assets/repository_test.py
@@ -4,25 +4,25 @@ from ostorlab.agent.message import serializer
 from ostorlab.assets import repository as repository_asset
 
 
-def testToProto_whenOriginUrlSet_returnsSerializedBytes():
+def testToProto_whenRepositoryUrlSet_returnsSerializedBytes():
     raw = repository_asset.Repository(
-        origin_url="https://github.com/org/repo.git",
+        repository_url="https://github.com/org/repo.git",
         commit_hash="a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
     ).to_proto()
 
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.repository", raw)
-    assert unraw.origin_url == "https://github.com/org/repo.git"
+    assert unraw.repository_url == "https://github.com/org/repo.git"
     assert unraw.commit_hash == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
 
 
-def testToProto_whenOriginUrlSetAndDifferentCommit_returnsSerializedBytes():
+def testToProto_whenRepositoryUrlSetAndDifferentCommit_returnsSerializedBytes():
     raw = repository_asset.Repository(
-        origin_url="https://gitlab.com/org/repo.git",
+        repository_url="https://gitlab.com/org/repo.git",
         commit_hash="b2b20cdbc6551ba359169a3033f193b7f8c1b95e",
     ).to_proto()
 
     assert isinstance(raw, bytes)
     unraw = serializer.deserialize("v3.asset.repository", raw)
-    assert unraw.origin_url == "https://gitlab.com/org/repo.git"
+    assert unraw.repository_url == "https://gitlab.com/org/repo.git"
     assert unraw.commit_hash == "b2b20cdbc6551ba359169a3033f193b7f8c1b95e"

--- a/tests/cli/scan/run/assets/repository_test.py
+++ b/tests/cli/scan/run/assets/repository_test.py
@@ -1,6 +1,4 @@
-"""Tests for the `oxo scan run repository` CLI command, covering --file and --url options."""
-
-import pathlib
+"""Tests for the `oxo scan run repository` CLI command."""
 
 from click import testing
 from pytest_mock import plugin
@@ -9,18 +7,7 @@ from ostorlab.assets import repository as repository_asset
 from ostorlab.cli import rootcli
 
 
-def testScanRunRepository_whenNoOptionsProvided_exitsWithError(
-    scan_run_cli_runner: testing.CliRunner,
-) -> None:
-    result = scan_run_cli_runner.invoke(
-        rootcli.rootcli, ["scan", "run", "--agent=agent1", "repository"]
-    )
-
-    assert result.exit_code == 2
-    assert "Command accepts either --file or --url." in result.output
-
-
-def testScanRunRepository_whenUrlProvided_callsScanWithRepositoryAsset(
+def testScanRunRepository_whenOriginUrlProvided_callsScanWithRepositoryAsset(
     scan_run_cli_runner: testing.CliRunner,
     mocker: plugin.MockerFixture,
 ) -> None:
@@ -35,45 +22,7 @@ def testScanRunRepository_whenUrlProvided_callsScanWithRepositoryAsset(
             "run",
             "--agent=agent1",
             "repository",
-            "--url",
-            "https://storage.example.com/repo.zip",
-            "--repo-url",
-            "https://github.com/org/repo.git",
-            "--commit-hash",
-            "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert scan_mocked.call_count == 1
-    assets = scan_mocked.call_args[1].get("assets")
-    assert len(assets) == 1
-    assert isinstance(assets[0], repository_asset.Repository)
-    assert assets[0].origin_url == "https://github.com/org/repo.git"
-    assert assets[0].commit_hash == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
-
-
-def testScanRunRepository_whenFileProvided_callsScanWithRepositoryAsset(
-    scan_run_cli_runner: testing.CliRunner,
-    mocker: plugin.MockerFixture,
-    tmp_path: pathlib.Path,
-) -> None:
-    scan_mocked = mocker.patch(
-        "ostorlab.runtimes.local.LocalRuntime.scan", return_value=None
-    )
-    archive = tmp_path / "repo.zip"
-    archive.write_bytes(b"PK\x03\x04archive_content")
-
-    result = scan_run_cli_runner.invoke(
-        rootcli.rootcli,
-        [
-            "scan",
-            "run",
-            "--agent=agent1",
-            "repository",
-            "--file",
-            str(archive),
-            "--repo-url",
+            "--origin-url",
             "https://github.com/org/repo.git",
             "--commit-hash",
             "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",

--- a/tests/cli/scan/run/assets/repository_test.py
+++ b/tests/cli/scan/run/assets/repository_test.py
@@ -49,8 +49,7 @@ def testScanRunRepository_whenUrlProvided_callsScanWithRepositoryAsset(
     assets = scan_mocked.call_args[1].get("assets")
     assert len(assets) == 1
     assert isinstance(assets[0], repository_asset.Repository)
-    assert assets[0].content_url == "https://storage.example.com/repo.zip"
-    assert assets[0].repo_url == "https://github.com/org/repo.git"
+    assert assets[0].origin_url == "https://github.com/org/repo.git"
     assert assets[0].commit_hash == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
 
 
@@ -86,5 +85,5 @@ def testScanRunRepository_whenFileProvided_callsScanWithRepositoryAsset(
     assets = scan_mocked.call_args[1].get("assets")
     assert len(assets) == 1
     assert isinstance(assets[0], repository_asset.Repository)
-    assert assets[0].content == b"PK\x03\x04archive_content"
-    assert assets[0].repo_url == "https://github.com/org/repo.git"
+    assert assets[0].origin_url == "https://github.com/org/repo.git"
+    assert assets[0].commit_hash == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"

--- a/tests/cli/scan/run/assets/repository_test.py
+++ b/tests/cli/scan/run/assets/repository_test.py
@@ -7,7 +7,7 @@ from ostorlab.assets import repository as repository_asset
 from ostorlab.cli import rootcli
 
 
-def testScanRunRepository_whenOriginUrlProvided_callsScanWithRepositoryAsset(
+def testScanRunRepository_whenRepositoryUrlProvided_callsScanWithRepositoryAsset(
     scan_run_cli_runner: testing.CliRunner,
     mocker: plugin.MockerFixture,
 ) -> None:
@@ -22,7 +22,7 @@ def testScanRunRepository_whenOriginUrlProvided_callsScanWithRepositoryAsset(
             "run",
             "--agent=agent1",
             "repository",
-            "--origin-url",
+            "--repository-url",
             "https://github.com/org/repo.git",
             "--commit-hash",
             "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
@@ -34,5 +34,5 @@ def testScanRunRepository_whenOriginUrlProvided_callsScanWithRepositoryAsset(
     assets = scan_mocked.call_args[1].get("assets")
     assert len(assets) == 1
     assert isinstance(assets[0], repository_asset.Repository)
-    assert assets[0].origin_url == "https://github.com/org/repo.git"
+    assert assets[0].repository_url == "https://github.com/org/repo.git"
     assert assets[0].commit_hash == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"


### PR DESCRIPTION
##  Repository Asset Proto Update

###  Summary

Update the repository asset protobuf schema to `proto2` with:

- `origin_url`
- `commit_hash`

Also align the Python asset model, CLI, and tests with the new fields.

###  Validation

Verified with:

- `tests/agent/message/proto/v3/asset/repository/repository_pb2_test.py`
- `tests/assets/repository_test.py`
- `tests/cli/scan/run/assets/repository_test.py`
