### PR TITLE
fix: fix issue `start_a` sometimes crashes when starting a scan

### DIFF
--- a/src/ostorlab/runtimes/lite_local/runtime.py
+++ b/src/ostorlab/runtimes/lite_local/runtime.py
@@ -136,7 +136,7 @@ class LiteLocalRuntime(runtime.Runtime):
         else:
             if not docker_requirements_checker.is_swarm_initialized():
                 docker_requirements_checker.init_swarm()
-            self._docker_client = docker.from_env()
+            self._docker_client = docker.from_env(max_pool_size=100)
 
     @property
     def name(self) -> str:

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -171,7 +171,7 @@ class LocalRuntime(runtime.Runtime):
             if not docker_requirements_checker.is_swarm_initialized():
                 docker_requirements_checker.init_swarm()
 
-        self._docker_client = docker.from_env()
+        self._docker_client = docker.from_env(max_pool_size=100)
 
     def prepare_scan(
         self, title: str, assets: Optional[List[base_asset.Asset]]

--- a/tests/runtimes/lite_local/runtime_test.py
+++ b/tests/runtimes/lite_local/runtime_test.py
@@ -542,3 +542,38 @@ def testCreateScanVolumeMounts_whenVolumeIsMissing_createsSharedScanVolumeMounts
         "type": "volume",
         "read_only": False,
     }
+
+
+def testLiteLocalRuntimeInit_always_setsMaxPoolSize(mocker):
+    """Test LiteLocalRuntime initializes docker client with increased pool size."""
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_installed",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_sys_arch_supported",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_user_permitted", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_working", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_swarm_initialized",
+        return_value=True,
+    )
+    mock_from_env = mocker.patch("docker.from_env")
+
+    lite_local_runtime.LiteLocalRuntime(
+        scan_id="1",
+        bus_url="bus",
+        bus_vhost="/",
+        bus_management_url="mgmt",
+        bus_exchange_topic="topic",
+        network="privnet",
+        redis_url="redis://redis",
+        tracing_collector_url="jaeger://localhost/",
+    )
+    mock_from_env.assert_called_once_with(max_pool_size=100)

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -432,3 +432,26 @@ def testRuntimeScanStop_whenUnrelatedNetworks_removesScanServiceWithoutCrash(
 
     docker_service_remove.assert_called_once()
     docker_network_remove.assert_called_once()
+
+
+def testLocalRuntimeInit_always_setsMaxPoolSize(mocker):
+    """Test LocalRuntime initializes docker client with increased pool size."""
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_working", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_sys_arch_supported",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_user_permitted", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_swarm_initialized",
+        return_value=True,
+    )
+    mock_from_env = mocker.patch("docker.from_env")
+
+    runtime = local_runtime.LocalRuntime()
+    runtime._docker_checks()
+    mock_from_env.assert_any_call(max_pool_size=100)


### PR DESCRIPTION
(docker-py) uses the requests and `urllib3` libraries to communicate with the Docker daemon.

By default, requests limits its connection pool size to 10.

When _start_agents uses `futures.ThreadPoolExecutor()` to spawn multiple agents concurrently, and there are more than 10 agents, the threads easily exhaust the Docker client's default connection pool. 

This causes urllib3 to log the Connection pool is full, discarding connection: localhost warning. Some threads are unable to get an available connection in time, eventually leading to communication failures with Docker. and start_a docker service (oxo:latest) is scaled down

<img width="1853" height="232" alt="image" src="https://github.com/user-attachments/assets/01d62249-8b3b-48ee-b37a-8382b387c4be" />
