### PR TITLE
fix: add event loop guard in agentMixin

### DIFF
--- a/src/ostorlab/agent/mixins/agent_mq_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_mq_mixin.py
@@ -43,7 +43,14 @@ class AgentMQMixin:
         self._queue_name = f"{self._name}_queue"
         self._url = url
         self._topic = topic
-        self._loop = loop or asyncio.get_event_loop()
+        if loop is not None:
+            self._loop = loop
+        else:
+            try:
+                self._loop = asyncio.get_event_loop()
+            except RuntimeError:
+                self._loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self._loop)
         self._max_priority = max_priority
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
         self._queue: Optional[aio_pika.Queue] = None

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -155,6 +155,25 @@ def testMqSendMessage_onConnectionResetError_shouldRetriesAndReraise(
     assert mock_send_message.call_count == 6
 
 
+def testAgentMqMixin_whenNoCurrentLoop_shouldCreateEventLoop(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Test that AgentMQMixin creates a loop when none is available."""
+    mocker.patch("asyncio.get_event_loop", side_effect=RuntimeError)
+    new_event_loop = mocker.patch("asyncio.new_event_loop")
+    set_event_loop = mocker.patch("asyncio.set_event_loop")
+
+    agent = agent_mq_mixin.AgentMQMixin(
+        name="test",
+        keys=["a.#"],
+        url="amqp://guest:guest@localhost:5672/",
+        topic="test_topic",
+    )
+
+    assert agent._loop is new_event_loop.return_value
+    set_event_loop.assert_called_once_with(new_event_loop.return_value)
+
+
 def testMqSendMessage_onCanceledError_shouldRetryAndReraise(
     mocker: plugin.MockerFixture,
 ) -> None:

--- a/tests/agent/mixins/agent_mq_mixin_test.py
+++ b/tests/agent/mixins/agent_mq_mixin_test.py
@@ -174,6 +174,24 @@ def testAgentMqMixin_whenNoCurrentLoop_shouldCreateEventLoop(
     set_event_loop.assert_called_once_with(new_event_loop.return_value)
 
 
+def testAgentMqMixin_whenLoopIsProvided_usesProvidedLoop(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Test that AgentMQMixin uses the explicitly provided event loop."""
+    provided_loop = asyncio.new_event_loop()
+    get_event_loop = mocker.patch("asyncio.get_event_loop")
+    agent = agent_mq_mixin.AgentMQMixin(
+        name="test",
+        keys=["a.#"],
+        url="amqp://guest:guest@localhost:5672/",
+        topic="test_topic",
+        loop=provided_loop,
+    )
+    assert agent._loop is provided_loop
+    get_event_loop.assert_not_called()
+    provided_loop.close()
+
+
 def testMqSendMessage_onCanceledError_shouldRetryAndReraise(
     mocker: plugin.MockerFixture,
 ) -> None:


### PR DESCRIPTION
Fix `AgentMQMixin` initialization when no current asyncio event loop is set.

`AgentMQMixin.__init__()` previously called `asyncio.get_event_loop()` directly when no loop was provided. In full test runs, earlier async tests can leave the main thread without a current loop, causing sync MQ tests to fail with `RuntimeError: There is no current event loop in thread 'MainThread'`.

This change aligns `AgentMQMixin` with the existing guard already used in `Agent`:
- use the provided loop when available
- otherwise try `asyncio.get_event_loop()`
- if no loop exists, create one with `asyncio.new_event_loop()` and register it with `asyncio.set_event_loop()`

This keeps the fix narrowly scoped to MQ mixin initialization and makes direct `AgentMQMixin` usage safe in synchronous contexts.