### PR TITLE
fix: provider serialization in Repository asset and add corresponding unit test

### DIFF
--- a/src/ostorlab/assets/repository.py
+++ b/src/ostorlab/assets/repository.py
@@ -15,7 +15,7 @@ class Repository(asset.Asset):
     provider: str = ""
 
     def __post_init__(self) -> None:
-        if not self.provider:
+        if self.provider == "":
             del self.provider
 
     def __str__(self) -> str:

--- a/src/ostorlab/assets/repository.py
+++ b/src/ostorlab/assets/repository.py
@@ -14,6 +14,10 @@ class Repository(asset.Asset):
     commit_hash: str = ""
     provider: str = ""
 
+    def __post_init__(self) -> None:
+        if not self.provider:
+            del self.provider
+
     def __str__(self) -> str:
         if self.repository_url != "":
             if self.commit_hash != "":

--- a/tests/assets/repository_test.py
+++ b/tests/assets/repository_test.py
@@ -31,3 +31,18 @@ def testToProto_whenRepositoryUrlSetAndDifferentCommit_returnsSerializedBytes():
     assert unraw.repository_url == "https://gitlab.com/org/repo.git"
     assert unraw.commit_hash == "b2b20cdbc6551ba359169a3033f193b7f8c1b95e"
     assert unraw.provider == repository_pb2.Message.AZURE
+
+
+def testToProto_whenProviderIsNotSet_returnsSerializedBytes():
+    asset = repository_asset.Repository(
+        repository_url="https://github.com/org/repo.git",
+        commit_hash="a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+    )
+
+    raw = asset.to_proto()
+
+    assert isinstance(raw, bytes)
+    assert "provider" not in asset.__dict__
+    unraw = serializer.deserialize("v3.asset.repository", raw)
+    assert unraw.repository_url == "https://github.com/org/repo.git"
+    assert unraw.commit_hash == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"

--- a/tests/assets/repository_test.py
+++ b/tests/assets/repository_test.py
@@ -5,7 +5,7 @@ from ostorlab.agent.message.proto.v3.asset.repository import repository_pb2
 from ostorlab.assets import repository as repository_asset
 
 
-def testToProto_whenRepositoryUrlSet_returnsSerializedBytes():
+def testToProto_whenRepositoryUrlSet_returnsSerializedBytes() -> None:
     raw = repository_asset.Repository(
         repository_url="https://github.com/org/repo.git",
         commit_hash="a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
@@ -19,7 +19,7 @@ def testToProto_whenRepositoryUrlSet_returnsSerializedBytes():
     assert unraw.provider == repository_pb2.Message.GITHUB
 
 
-def testToProto_whenRepositoryUrlSetAndDifferentCommit_returnsSerializedBytes():
+def testToProto_whenRepositoryUrlSetAndDifferentCommit_returnsSerializedBytes() -> None:
     raw = repository_asset.Repository(
         repository_url="https://gitlab.com/org/repo.git",
         commit_hash="b2b20cdbc6551ba359169a3033f193b7f8c1b95e",
@@ -33,7 +33,7 @@ def testToProto_whenRepositoryUrlSetAndDifferentCommit_returnsSerializedBytes():
     assert unraw.provider == repository_pb2.Message.AZURE
 
 
-def testToProto_whenProviderIsNotSet_returnsSerializedBytes():
+def testToProto_whenProviderIsNotSet_returnsSerializedBytes() -> None:
     asset = repository_asset.Repository(
         repository_url="https://github.com/org/repo.git",
         commit_hash="a1a10cdbc6551ba359169a3033f193b7f8c1b95d",


### PR DESCRIPTION
## Summary

Fix repository asset serialization when the provider is omitted.

## Changes

- Remove an empty `provider` from the repository asset before serialization.
- Prevent the protobuf serializer from parsing an empty string as an enum.
- Add a regression test for repositories without a provider.
