### PR TITLE
feature: optional experimental arg for agent experimental channel

### DIFF
--- a/.github/workflows/lint_format_checker.yaml
+++ b/.github/workflows/lint_format_checker.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.14" ]
+        python-version: [ "3.13", "3.14" ]
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest-linux.yml
+++ b/.github/workflows/pytest-linux.yml
@@ -1,6 +1,6 @@
 # This workflow use pytest:
 #  - Install Python dependencies.
-#  - Run pytest for each of the supported Python versions ["3.8", "3.9", "3.10"]. 
+#  - Run pytest for each of the supported Python versions ["3.13", "3.14"].
 # Running pytest with -m "no docker" to disable test that require a docker installation.
 
 name: Pytest-Linux
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11" ,"3.14"]
+        python-version: ["3.13", "3.14"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -1,6 +1,6 @@
 # This workflow use pytest:
 #  - Install Python dependencies.
-#  - Run pytest for each of the supported Python versions ["3.8", "3.9", "3.10"]. 
+#  - Run pytest for each of the supported Python versions ["3.13", "3.14"].
 # Running pytest with -m "no docker" to disable test that require a docker installation.
 
 name: Pytest-Windows
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11" ,"3.14"]
+        python-version: ["3.13", "3.14"]
         os: [windows-latest]
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.x'
+        python-version: '3.13'
     - name: Install SSH key
       uses: shimataro/ssh-key-action@v2
       with:

--- a/.github/workflows/typing_checker.yaml
+++ b/.github/workflows/typing_checker.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.14" ]
+        python-version: [ "3.13", "3.14" ]
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-python_requires = >=3.9
+python_requires = >=3.13
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in

--- a/src/ostorlab/apis/agent_details.py
+++ b/src/ostorlab/apis/agent_details.py
@@ -9,9 +9,7 @@ from ostorlab.apis import request
 class AgentDetailsAPIRequest(request.APIRequest):
     """Get agent details for a specified agent_key."""
 
-    def __init__(
-        self, agent_key: str, use_experimental: bool = False
-    ) -> None:
+    def __init__(self, agent_key: str, use_experimental: bool = False) -> None:
         """Initializer"""
         self._agent_key = agent_key
         self._use_experimental = use_experimental

--- a/src/ostorlab/apis/agent_details.py
+++ b/src/ostorlab/apis/agent_details.py
@@ -21,8 +21,27 @@ class AgentDetailsAPIRequest(request.APIRequest):
         Returns:
             The query to fetch the agent details.
         """
+        if self._use_experimental is True:
+            return """
+                query Agent($agentKey: String!, $useExperimental: Boolean){
+                    agent(agentKey: $agentKey) {
+                        name,
+                        gitLocation,
+                        yamlFileLocation,
+                        dockerLocation,
+                        access,
+                        listable,
+                        key
+                        versions(orderBy: Version, sort: Desc, page: 1, numberElements: 1, useExperimental: $useExperimental) {
+                          versions {
+                            version
+                          }
+                        }
+                    }
+                }
+            """
         return """
-            query Agent($agentKey: String!, $useExperimental: Boolean){
+            query Agent($agentKey: String!){
                 agent(agentKey: $agentKey) {
                     name,
                     gitLocation,
@@ -31,7 +50,7 @@ class AgentDetailsAPIRequest(request.APIRequest):
                     access,
                     listable,
                     key
-                    versions(orderBy: Version, sort: Desc, page: 1, numberElements: 1, useExperimental: $useExperimental) {
+                    versions(orderBy: Version, sort: Desc, page: 1, numberElements: 1) {
                       versions {
                         version
                       }
@@ -47,10 +66,9 @@ class AgentDetailsAPIRequest(request.APIRequest):
         Returns:
             The body of the agent details request.
         """
-        variables: Dict[str, Any] = {
-            "agentKey": self._agent_key,
-            "useExperimental": self._use_experimental,
-        }
+        variables: Dict[str, Any] = {"agentKey": self._agent_key}
+        if self._use_experimental is True:
+            variables["useExperimental"] = True
         data = {
             "query": self.query,
             "variables": json.dumps(variables),

--- a/src/ostorlab/apis/agent_details.py
+++ b/src/ostorlab/apis/agent_details.py
@@ -9,9 +9,12 @@ from ostorlab.apis import request
 class AgentDetailsAPIRequest(request.APIRequest):
     """Get agent details for a specified agent_key."""
 
-    def __init__(self, agent_key: str) -> None:
+    def __init__(
+        self, agent_key: str, reporting_scan_id: Optional[int] = None
+    ) -> None:
         """Initializer"""
         self._agent_key = agent_key
+        self._reporting_scan_id = reporting_scan_id
 
     @property
     def query(self) -> Optional[str]:
@@ -21,7 +24,7 @@ class AgentDetailsAPIRequest(request.APIRequest):
             The query to fetch the agent details.
         """
         return """
-            query Agent($agentKey: String!){
+            query Agent($agentKey: String!, $reportingScanId: Int){
                 agent(agentKey: $agentKey) {
                     name,
                     gitLocation,
@@ -30,7 +33,7 @@ class AgentDetailsAPIRequest(request.APIRequest):
                     access,
                     listable,
                     key
-                    versions(orderBy: Version, sort: Desc, page: 1, numberElements: 1) {
+                    versions(orderBy: Version, sort: Desc, page: 1, numberElements: 1, reportingScanId: $reportingScanId) {
                       versions {
                         version
                       }
@@ -46,8 +49,11 @@ class AgentDetailsAPIRequest(request.APIRequest):
         Returns:
             The body of the agent details request.
         """
+        variables: Dict[str, Any] = {"agentKey": self._agent_key}
+        if self._reporting_scan_id is not None:
+            variables["reportingScanId"] = self._reporting_scan_id
         data = {
             "query": self.query,
-            "variables": json.dumps({"agentKey": self._agent_key}),
+            "variables": json.dumps(variables),
         }
         return data

--- a/src/ostorlab/apis/agent_details.py
+++ b/src/ostorlab/apis/agent_details.py
@@ -1,7 +1,7 @@
 """Get agent details from the public api."""
 
 import json
-from typing import Dict, Optional, Any
+from typing import Any
 
 from ostorlab.apis import request
 
@@ -15,33 +15,14 @@ class AgentDetailsAPIRequest(request.APIRequest):
         self._use_experimental = use_experimental
 
     @property
-    def query(self) -> Optional[str]:
+    def query(self) -> str:
         """The query to fetch the agent details with an agent key.
 
         Returns:
             The query to fetch the agent details.
         """
-        if self._use_experimental is True:
-            return """
-                query Agent($agentKey: String!, $useExperimental: Boolean){
-                    agent(agentKey: $agentKey) {
-                        name,
-                        gitLocation,
-                        yamlFileLocation,
-                        dockerLocation,
-                        access,
-                        listable,
-                        key
-                        versions(orderBy: Version, sort: Desc, page: 1, numberElements: 1, useExperimental: $useExperimental) {
-                          versions {
-                            version
-                          }
-                        }
-                    }
-                }
-            """
         return """
-            query Agent($agentKey: String!){
+            query Agent($agentKey: String!, $useExperimental: Boolean){
                 agent(agentKey: $agentKey) {
                     name,
                     gitLocation,
@@ -50,7 +31,7 @@ class AgentDetailsAPIRequest(request.APIRequest):
                     access,
                     listable,
                     key
-                    versions(orderBy: Version, sort: Desc, page: 1, numberElements: 1) {
+                    versions(orderBy: Version, sort: Desc, page: 1, numberElements: 1, useExperimental: $useExperimental) {
                       versions {
                         version
                       }
@@ -60,17 +41,15 @@ class AgentDetailsAPIRequest(request.APIRequest):
         """
 
     @property
-    def data(self) -> Optional[Dict[str, Any]]:
+    def data(self) -> dict[str, Any]:
         """Sets the body of the API request, to fetch the specific agent.
 
         Returns:
             The body of the agent details request.
         """
-        variables: Dict[str, Any] = {"agentKey": self._agent_key}
-        if self._use_experimental is True:
-            variables["useExperimental"] = True
-        data = {
+        return {
             "query": self.query,
-            "variables": json.dumps(variables),
+            "variables": json.dumps(
+                {"agentKey": self._agent_key, "useExperimental": self._use_experimental}
+            ),
         }
-        return data

--- a/src/ostorlab/apis/agent_details.py
+++ b/src/ostorlab/apis/agent_details.py
@@ -10,11 +10,11 @@ class AgentDetailsAPIRequest(request.APIRequest):
     """Get agent details for a specified agent_key."""
 
     def __init__(
-        self, agent_key: str, reporting_scan_id: Optional[int] = None
+        self, agent_key: str, use_experimental: bool = False
     ) -> None:
         """Initializer"""
         self._agent_key = agent_key
-        self._reporting_scan_id = reporting_scan_id
+        self._use_experimental = use_experimental
 
     @property
     def query(self) -> Optional[str]:
@@ -24,7 +24,7 @@ class AgentDetailsAPIRequest(request.APIRequest):
             The query to fetch the agent details.
         """
         return """
-            query Agent($agentKey: String!, $reportingScanId: Int){
+            query Agent($agentKey: String!, $useExperimental: Boolean){
                 agent(agentKey: $agentKey) {
                     name,
                     gitLocation,
@@ -33,7 +33,7 @@ class AgentDetailsAPIRequest(request.APIRequest):
                     access,
                     listable,
                     key
-                    versions(orderBy: Version, sort: Desc, page: 1, numberElements: 1, reportingScanId: $reportingScanId) {
+                    versions(orderBy: Version, sort: Desc, page: 1, numberElements: 1, useExperimental: $useExperimental) {
                       versions {
                         version
                       }
@@ -49,9 +49,10 @@ class AgentDetailsAPIRequest(request.APIRequest):
         Returns:
             The body of the agent details request.
         """
-        variables: Dict[str, Any] = {"agentKey": self._agent_key}
-        if self._reporting_scan_id is not None:
-            variables["reportingScanId"] = self._reporting_scan_id
+        variables: Dict[str, Any] = {
+            "agentKey": self._agent_key,
+            "useExperimental": self._use_experimental,
+        }
         data = {
             "query": self.query,
             "variables": json.dumps(variables),

--- a/src/ostorlab/cli/agent_fetcher.py
+++ b/src/ostorlab/cli/agent_fetcher.py
@@ -30,15 +30,14 @@ class AgentDetailsNotFound(Error):
 
 
 def get_details(
-    agent_key: str, reporting_scan_id: int | None = None
+    agent_key: str, use_experimental: bool = False
 ) -> dict[str, Any]:
     """Sends an API request with the agent key, and retrieve the agent information.
 
     Args:
         agent_key: the agent key in the form : agent/org/name
-        reporting_scan_id: optional reporting_engine scan id, used to resolve the
-            calling organisation's experimental channel opt-in when picking the
-            latest version.
+        use_experimental: when True, the server includes experimental (prerelease)
+            versions in the result set for this agent.
 
     Returns:
         dictionary of the agent information like : name, dockerLocation..
@@ -56,7 +55,7 @@ def get_details(
     try:
         response = runner.execute(
             agent_details_api.AgentDetailsAPIRequest(
-                agent_key, reporting_scan_id=reporting_scan_id
+                agent_key, use_experimental=use_experimental
             )
         )
     except base_runner.ResponseError as e:

--- a/src/ostorlab/cli/agent_fetcher.py
+++ b/src/ostorlab/cli/agent_fetcher.py
@@ -29,11 +29,16 @@ class AgentDetailsNotFound(Error):
     """Agent not found error."""
 
 
-def get_details(agent_key: str) -> dict[str, Any]:
+def get_details(
+    agent_key: str, reporting_scan_id: int | None = None
+) -> dict[str, Any]:
     """Sends an API request with the agent key, and retrieve the agent information.
 
     Args:
         agent_key: the agent key in the form : agent/org/name
+        reporting_scan_id: optional reporting_engine scan id, used to resolve the
+            calling organisation's experimental channel opt-in when picking the
+            latest version.
 
     Returns:
         dictionary of the agent information like : name, dockerLocation..
@@ -49,7 +54,11 @@ def get_details(agent_key: str) -> dict[str, Any]:
         runner = public_runner.PublicAPIRunner()
 
     try:
-        response = runner.execute(agent_details_api.AgentDetailsAPIRequest(agent_key))
+        response = runner.execute(
+            agent_details_api.AgentDetailsAPIRequest(
+                agent_key, reporting_scan_id=reporting_scan_id
+            )
+        )
     except base_runner.ResponseError as e:
         raise AgentDetailsNotFound("requested agent not found") from e
 

--- a/src/ostorlab/cli/agent_fetcher.py
+++ b/src/ostorlab/cli/agent_fetcher.py
@@ -29,9 +29,7 @@ class AgentDetailsNotFound(Error):
     """Agent not found error."""
 
 
-def get_details(
-    agent_key: str, use_experimental: bool = False
-) -> dict[str, Any]:
+def get_details(agent_key: str, use_experimental: bool = False) -> dict[str, Any]:
     """Sends an API request with the agent key, and retrieve the agent information.
 
     Args:

--- a/src/ostorlab/cli/scan/run/run.py
+++ b/src/ostorlab/cli/scan/run/run.py
@@ -197,7 +197,7 @@ def run(
                 _install_agents_with_retry(
                     runtime_instance,
                     agent_group,
-                    reporting_scan_id=ctx.obj.get("reporting_scan_id"),
+                    use_experimental=ctx.obj.get("use_experimental_agents", False),
                 )
             except httpx.HTTPError as e:
                 console.error(f"Could not install the agents: {e}")
@@ -238,7 +238,7 @@ def run(
 def _install_agents_with_retry(
     runtime_instance: runtime.Runtime,
     agent_group: definitions.AgentGroupDefinition,
-    reporting_scan_id: Optional[int] = None,
+    use_experimental: bool = False,
 ) -> None:
     # Trigger both the runtime installation routine and install all the provided agents.
     runtime_instance.install()
@@ -247,7 +247,7 @@ def _install_agents_with_retry(
             if ag.version is None:
                 try:
                     agent_details = agent_fetcher.get_details(
-                        ag.key, reporting_scan_id=reporting_scan_id
+                        ag.key, use_experimental=use_experimental
                     )
                     ag.version = agent_details["versions"]["versions"][0]["version"]
                 except agent_fetcher.AgentDetailsNotFound:

--- a/src/ostorlab/cli/scan/run/run.py
+++ b/src/ostorlab/cli/scan/run/run.py
@@ -194,7 +194,11 @@ def run(
         ctx.obj["title"] = title
         if install is True:
             try:
-                _install_agents_with_retry(runtime_instance, agent_group)
+                _install_agents_with_retry(
+                    runtime_instance,
+                    agent_group,
+                    reporting_scan_id=ctx.obj.get("reporting_scan_id"),
+                )
             except httpx.HTTPError as e:
                 console.error(f"Could not install the agents: {e}")
                 raise click.exceptions.Exit(1)
@@ -232,7 +236,9 @@ def run(
     retry_error_callback=lambda retry_state: retry_state.outcome.result(),
 )
 def _install_agents_with_retry(
-    runtime_instance: runtime.Runtime, agent_group: definitions.AgentGroupDefinition
+    runtime_instance: runtime.Runtime,
+    agent_group: definitions.AgentGroupDefinition,
+    reporting_scan_id: Optional[int] = None,
 ) -> None:
     # Trigger both the runtime installation routine and install all the provided agents.
     runtime_instance.install()
@@ -240,7 +246,9 @@ def _install_agents_with_retry(
         try:
             if ag.version is None:
                 try:
-                    agent_details = agent_fetcher.get_details(ag.key)
+                    agent_details = agent_fetcher.get_details(
+                        ag.key, reporting_scan_id=reporting_scan_id
+                    )
                     ag.version = agent_details["versions"]["versions"][0]["version"]
                 except agent_fetcher.AgentDetailsNotFound:
                     logger.warning(

--- a/src/ostorlab/cli/scan/run/run.py
+++ b/src/ostorlab/cli/scan/run/run.py
@@ -109,13 +109,6 @@ WAIT_BETWEEN_RETRIES = 5
     help="Init sleep for tracker before checking the queues",
     required=False,
 )
-@click.option(
-    "--use-experimental-agents",
-    is_flag=True,
-    default=False,
-    help="When set, experimental (prerelease) agent versions are eligible during install.",
-    hidden=True,
-)
 @click.pass_context
 def run(
     ctx: click.core.Context,
@@ -131,7 +124,6 @@ def run(
     no_asset: bool,
     timeout: Optional[int] = None,
     init_sleep: Optional[int] = None,
-    use_experimental_agents: bool = False,
 ) -> None:
     """Start a new scan on your assets.\n
     Example:\n
@@ -205,7 +197,7 @@ def run(
                 _install_agents_with_retry(
                     runtime_instance,
                     agent_group,
-                    use_experimental=use_experimental_agents,
+                    use_experimental=ctx.obj.get("use_experimental_agents", False),
                 )
             except httpx.HTTPError as e:
                 console.error(f"Could not install the agents: {e}")

--- a/src/ostorlab/cli/scan/run/run.py
+++ b/src/ostorlab/cli/scan/run/run.py
@@ -194,13 +194,14 @@ def run(
         ctx.obj["title"] = title
         if install is True:
             try:
+                use_experimental = (
+                    ctx.obj.get("use_experimental_agents", False) is True
+                    or agent_group.use_experimental_agents is True
+                )
                 _install_agents_with_retry(
                     runtime_instance,
                     agent_group,
-                    use_experimental=(
-                        ctx.obj.get("use_experimental_agents", False)
-                        or agent_group.use_experimental_agents
-                    ),
+                    use_experimental=use_experimental,
                 )
             except httpx.HTTPError as e:
                 console.error(f"Could not install the agents: {e}")

--- a/src/ostorlab/cli/scan/run/run.py
+++ b/src/ostorlab/cli/scan/run/run.py
@@ -197,7 +197,10 @@ def run(
                 _install_agents_with_retry(
                     runtime_instance,
                     agent_group,
-                    use_experimental=ctx.obj.get("use_experimental_agents", False),
+                    use_experimental=(
+                        ctx.obj.get("use_experimental_agents", False)
+                        or agent_group.use_experimental_agents
+                    ),
                 )
             except httpx.HTTPError as e:
                 console.error(f"Could not install the agents: {e}")

--- a/src/ostorlab/cli/scan/run/run.py
+++ b/src/ostorlab/cli/scan/run/run.py
@@ -109,6 +109,13 @@ WAIT_BETWEEN_RETRIES = 5
     help="Init sleep for tracker before checking the queues",
     required=False,
 )
+@click.option(
+    "--use-experimental-agents",
+    is_flag=True,
+    default=False,
+    help="When set, experimental (prerelease) agent versions are eligible during install.",
+    hidden=True,
+)
 @click.pass_context
 def run(
     ctx: click.core.Context,
@@ -124,6 +131,7 @@ def run(
     no_asset: bool,
     timeout: Optional[int] = None,
     init_sleep: Optional[int] = None,
+    use_experimental_agents: bool = False,
 ) -> None:
     """Start a new scan on your assets.\n
     Example:\n
@@ -197,7 +205,7 @@ def run(
                 _install_agents_with_retry(
                     runtime_instance,
                     agent_group,
-                    use_experimental=ctx.obj.get("use_experimental_agents", False),
+                    use_experimental=use_experimental_agents,
                 )
             except httpx.HTTPError as e:
                 console.error(f"Could not install the agents: {e}")

--- a/src/ostorlab/cli/scan/scan.py
+++ b/src/ostorlab/cli/scan/scan.py
@@ -65,6 +65,13 @@ from ostorlab.cli import input_validators
     required=False,
     hidden=True,
 )
+@click.option(
+    "--reporting-scan-id",
+    help="reporting_engine's scan id, used to resolve the calling organisation's "
+    "agent release channel when installing agents.",
+    required=False,
+    hidden=True,
+)
 @click.option("--tracing/--no-tracing", help="Enable tracing mode", default=False)
 @click.option(
     "--tracing-collector-url",
@@ -88,6 +95,7 @@ def scan(
     bus_management_url: Optional[str] = None,
     bus_exchange_topic: Optional[str] = None,
     scan_id: Optional[str] = None,
+    reporting_scan_id: Optional[str] = None,
     network: Optional[str] = None,
     redis_url: Optional[str] = None,
     tracing: bool = False,
@@ -123,6 +131,9 @@ def scan(
             gcp_logging_credential=ctx.obj.get("gcp_logging_credential"),
         )
         ctx.obj["runtime"] = runtime_instance
+        ctx.obj["reporting_scan_id"] = (
+            int(reporting_scan_id) if reporting_scan_id is not None else None
+        )
     except registry.RuntimeNotFoundError as e:
         raise click.ClickException(
             f"The selected runtime {runtime} is not supported."

--- a/src/ostorlab/cli/scan/scan.py
+++ b/src/ostorlab/cli/scan/scan.py
@@ -65,13 +65,6 @@ from ostorlab.cli import input_validators
     required=False,
     hidden=True,
 )
-@click.option(
-    "--use-experimental-agents",
-    is_flag=True,
-    default=False,
-    help="When set, experimental (prerelease) agent versions are eligible during install.",
-    hidden=True,
-)
 @click.option("--tracing/--no-tracing", help="Enable tracing mode", default=False)
 @click.option(
     "--tracing-collector-url",
@@ -95,7 +88,6 @@ def scan(
     bus_management_url: Optional[str] = None,
     bus_exchange_topic: Optional[str] = None,
     scan_id: Optional[str] = None,
-    use_experimental_agents: bool = False,
     network: Optional[str] = None,
     redis_url: Optional[str] = None,
     tracing: bool = False,
@@ -131,7 +123,6 @@ def scan(
             gcp_logging_credential=ctx.obj.get("gcp_logging_credential"),
         )
         ctx.obj["runtime"] = runtime_instance
-        ctx.obj["use_experimental_agents"] = use_experimental_agents
     except registry.RuntimeNotFoundError as e:
         raise click.ClickException(
             f"The selected runtime {runtime} is not supported."

--- a/src/ostorlab/cli/scan/scan.py
+++ b/src/ostorlab/cli/scan/scan.py
@@ -66,7 +66,9 @@ from ostorlab.cli import input_validators
     hidden=True,
 )
 @click.option(
-    "--use-experimental-agents",
+    "--experimental",
+    "-x",
+    "use_experimental_agents",
     is_flag=True,
     default=False,
     help="When set, experimental (prerelease) agent versions are eligible during install.",

--- a/src/ostorlab/cli/scan/scan.py
+++ b/src/ostorlab/cli/scan/scan.py
@@ -65,6 +65,13 @@ from ostorlab.cli import input_validators
     required=False,
     hidden=True,
 )
+@click.option(
+    "--use-experimental-agents",
+    is_flag=True,
+    default=False,
+    help="When set, experimental (prerelease) agent versions are eligible during install.",
+    hidden=True,
+)
 @click.option("--tracing/--no-tracing", help="Enable tracing mode", default=False)
 @click.option(
     "--tracing-collector-url",
@@ -88,6 +95,7 @@ def scan(
     bus_management_url: Optional[str] = None,
     bus_exchange_topic: Optional[str] = None,
     scan_id: Optional[str] = None,
+    use_experimental_agents: bool = False,
     network: Optional[str] = None,
     redis_url: Optional[str] = None,
     tracing: bool = False,
@@ -123,6 +131,7 @@ def scan(
             gcp_logging_credential=ctx.obj.get("gcp_logging_credential"),
         )
         ctx.obj["runtime"] = runtime_instance
+        ctx.obj["use_experimental_agents"] = use_experimental_agents
     except registry.RuntimeNotFoundError as e:
         raise click.ClickException(
             f"The selected runtime {runtime} is not supported."

--- a/src/ostorlab/cli/scan/scan.py
+++ b/src/ostorlab/cli/scan/scan.py
@@ -66,10 +66,10 @@ from ostorlab.cli import input_validators
     hidden=True,
 )
 @click.option(
-    "--reporting-scan-id",
-    help="reporting_engine's scan id, used to resolve the calling organisation's "
-    "agent release channel when installing agents.",
-    required=False,
+    "--use-experimental-agents",
+    is_flag=True,
+    default=False,
+    help="When set, experimental (prerelease) agent versions are eligible during install.",
     hidden=True,
 )
 @click.option("--tracing/--no-tracing", help="Enable tracing mode", default=False)
@@ -95,7 +95,7 @@ def scan(
     bus_management_url: Optional[str] = None,
     bus_exchange_topic: Optional[str] = None,
     scan_id: Optional[str] = None,
-    reporting_scan_id: Optional[str] = None,
+    use_experimental_agents: bool = False,
     network: Optional[str] = None,
     redis_url: Optional[str] = None,
     tracing: bool = False,
@@ -131,9 +131,7 @@ def scan(
             gcp_logging_credential=ctx.obj.get("gcp_logging_credential"),
         )
         ctx.obj["runtime"] = runtime_instance
-        ctx.obj["reporting_scan_id"] = (
-            int(reporting_scan_id) if reporting_scan_id is not None else None
-        )
+        ctx.obj["use_experimental_agents"] = use_experimental_agents
     except registry.RuntimeNotFoundError as e:
         raise click.ClickException(
             f"The selected runtime {runtime} is not supported."

--- a/src/ostorlab/runtimes/definitions.py
+++ b/src/ostorlab/runtimes/definitions.py
@@ -194,6 +194,7 @@ class AgentGroupDefinition:
     agents: List[AgentSettings]
     name: Optional[str] = None
     description: Optional[str] = None
+    use_experimental_agents: bool = False
 
     @classmethod
     def from_yaml(cls, group: io.FileIO):
@@ -245,7 +246,8 @@ class AgentGroupDefinition:
         description = agent_group_def.get(
             "description", f"""Agent group : {",".join(agents_names)}"""
         )
-        return cls(agent_settings, name, description)
+        use_experimental_agents = agent_group_def.get("use_experimental_agents", False)
+        return cls(agent_settings, name, description, use_experimental_agents)
 
     @classmethod
     def from_bus_message(cls, request):

--- a/tests/apis/agent_details_test.py
+++ b/tests/apis/agent_details_test.py
@@ -5,28 +5,28 @@ import json
 from ostorlab.apis import agent_details
 
 
-def testAgentDetailsAPIRequest_whenUseExperimentalFalse_omitsUseExperimentalFromVariables() -> (
+def testAgentDetailsAPIRequest_whenUseExperimentalFalse_sendsUseExperimentalFalseInVariables() -> (
     None
 ):
-    """Test that variables only contain agentKey when use_experimental is False (backward-compatible)."""
+    """Test that variables include useExperimental: False when use_experimental is not set."""
     api_request = agent_details.AgentDetailsAPIRequest(agent_key="agent/ostorlab/nmap")
 
     data = api_request.data
     variables = json.loads(data["variables"])
 
-    assert variables == {"agentKey": "agent/ostorlab/nmap"}
+    assert variables == {"agentKey": "agent/ostorlab/nmap", "useExperimental": False}
 
 
-def testAgentDetailsAPIRequest_whenUseExperimentalFalse_sendsQueryWithoutUseExperimentalArg() -> (
+def testAgentDetailsAPIRequest_whenUseExperimentalFalse_sendsQueryWithUseExperimentalArg() -> (
     None
 ):
-    """Test that the original query form (without useExperimental) is sent by default for backward compat."""
+    """Test that the query always includes the useExperimental argument regardless of value."""
     api_request = agent_details.AgentDetailsAPIRequest(agent_key="agent/ostorlab/nmap")
 
     query = api_request.query
 
-    assert "$useExperimental" not in query
-    assert "useExperimental:" not in query
+    assert "$useExperimental: Boolean" in query
+    assert "useExperimental: $useExperimental" in query
 
 
 def testAgentDetailsAPIRequest_whenUseExperimentalTrue_includesUseExperimentalInVariables() -> (

--- a/tests/apis/agent_details_test.py
+++ b/tests/apis/agent_details_test.py
@@ -5,39 +5,35 @@ import json
 from ostorlab.apis import agent_details
 
 
-def testAgentDetailsAPIRequest_whenNoReportingScanId_omitsReportingScanIdFromVariables() -> (
+def testAgentDetailsAPIRequest_whenUseExperimentalNotProvided_defaultsFalseInVariables() -> (
     None
 ):
-    """Test that variables only contain agentKey when reporting_scan_id is not provided."""
+    """Test that useExperimental defaults to False in variables when not provided."""
     api_request = agent_details.AgentDetailsAPIRequest(agent_key="agent/ostorlab/nmap")
 
     data = api_request.data
     variables = json.loads(data["variables"])
 
-    assert variables == {"agentKey": "agent/ostorlab/nmap"}
+    assert variables == {"agentKey": "agent/ostorlab/nmap", "useExperimental": False}
 
 
-def testAgentDetailsAPIRequest_whenReportingScanIdProvided_includesReportingScanIdInVariables() -> (
-    None
-):
-    """Test that variables contain reportingScanId when reporting_scan_id is provided."""
+def testAgentDetailsAPIRequest_whenUseExperimentalTrue_setsTrueInVariables() -> None:
+    """Test that variables carry useExperimental: true when opted in."""
     api_request = agent_details.AgentDetailsAPIRequest(
-        agent_key="agent/ostorlab/nmap", reporting_scan_id=42
+        agent_key="agent/ostorlab/nmap", use_experimental=True
     )
 
     data = api_request.data
     variables = json.loads(data["variables"])
 
-    assert variables == {"agentKey": "agent/ostorlab/nmap", "reportingScanId": 42}
+    assert variables == {"agentKey": "agent/ostorlab/nmap", "useExperimental": True}
 
 
-def testAgentDetailsAPIRequest_whenCalled_queryDeclaresReportingScanIdVariable() -> (
-    None
-):
-    """Test that the GraphQL query declares and forwards the reportingScanId variable."""
+def testAgentDetailsAPIRequest_whenCalled_queryDeclaresUseExperimentalVariable() -> None:
+    """Test that the GraphQL query declares and forwards the useExperimental variable."""
     api_request = agent_details.AgentDetailsAPIRequest(agent_key="agent/ostorlab/nmap")
 
     query = api_request.query
 
-    assert "$reportingScanId: Int" in query
-    assert "reportingScanId: $reportingScanId" in query
+    assert "$useExperimental: Boolean" in query
+    assert "useExperimental: $useExperimental" in query

--- a/tests/apis/agent_details_test.py
+++ b/tests/apis/agent_details_test.py
@@ -29,7 +29,9 @@ def testAgentDetailsAPIRequest_whenUseExperimentalTrue_setsTrueInVariables() -> 
     assert variables == {"agentKey": "agent/ostorlab/nmap", "useExperimental": True}
 
 
-def testAgentDetailsAPIRequest_whenCalled_queryDeclaresUseExperimentalVariable() -> None:
+def testAgentDetailsAPIRequest_whenCalled_queryDeclaresUseExperimentalVariable() -> (
+    None
+):
     """Test that the GraphQL query declares and forwards the useExperimental variable."""
     api_request = agent_details.AgentDetailsAPIRequest(agent_key="agent/ostorlab/nmap")
 

--- a/tests/apis/agent_details_test.py
+++ b/tests/apis/agent_details_test.py
@@ -1,0 +1,43 @@
+"""Unittests for the agent details API request."""
+
+import json
+
+from ostorlab.apis import agent_details
+
+
+def testAgentDetailsAPIRequest_whenNoReportingScanId_omitsReportingScanIdFromVariables() -> (
+    None
+):
+    """Test that variables only contain agentKey when reporting_scan_id is not provided."""
+    api_request = agent_details.AgentDetailsAPIRequest(agent_key="agent/ostorlab/nmap")
+
+    data = api_request.data
+    variables = json.loads(data["variables"])
+
+    assert variables == {"agentKey": "agent/ostorlab/nmap"}
+
+
+def testAgentDetailsAPIRequest_whenReportingScanIdProvided_includesReportingScanIdInVariables() -> (
+    None
+):
+    """Test that variables contain reportingScanId when reporting_scan_id is provided."""
+    api_request = agent_details.AgentDetailsAPIRequest(
+        agent_key="agent/ostorlab/nmap", reporting_scan_id=42
+    )
+
+    data = api_request.data
+    variables = json.loads(data["variables"])
+
+    assert variables == {"agentKey": "agent/ostorlab/nmap", "reportingScanId": 42}
+
+
+def testAgentDetailsAPIRequest_whenCalled_queryDeclaresReportingScanIdVariable() -> (
+    None
+):
+    """Test that the GraphQL query declares and forwards the reportingScanId variable."""
+    api_request = agent_details.AgentDetailsAPIRequest(agent_key="agent/ostorlab/nmap")
+
+    query = api_request.query
+
+    assert "$reportingScanId: Int" in query
+    assert "reportingScanId: $reportingScanId" in query

--- a/tests/apis/agent_details_test.py
+++ b/tests/apis/agent_details_test.py
@@ -5,19 +5,33 @@ import json
 from ostorlab.apis import agent_details
 
 
-def testAgentDetailsAPIRequest_whenUseExperimentalNotProvided_defaultsFalseInVariables() -> (
+def testAgentDetailsAPIRequest_whenUseExperimentalFalse_omitsUseExperimentalFromVariables() -> (
     None
 ):
-    """Test that useExperimental defaults to False in variables when not provided."""
+    """Test that variables only contain agentKey when use_experimental is False (backward-compatible)."""
     api_request = agent_details.AgentDetailsAPIRequest(agent_key="agent/ostorlab/nmap")
 
     data = api_request.data
     variables = json.loads(data["variables"])
 
-    assert variables == {"agentKey": "agent/ostorlab/nmap", "useExperimental": False}
+    assert variables == {"agentKey": "agent/ostorlab/nmap"}
 
 
-def testAgentDetailsAPIRequest_whenUseExperimentalTrue_setsTrueInVariables() -> None:
+def testAgentDetailsAPIRequest_whenUseExperimentalFalse_sendsQueryWithoutUseExperimentalArg() -> (
+    None
+):
+    """Test that the original query form (without useExperimental) is sent by default for backward compat."""
+    api_request = agent_details.AgentDetailsAPIRequest(agent_key="agent/ostorlab/nmap")
+
+    query = api_request.query
+
+    assert "$useExperimental" not in query
+    assert "useExperimental:" not in query
+
+
+def testAgentDetailsAPIRequest_whenUseExperimentalTrue_includesUseExperimentalInVariables() -> (
+    None
+):
     """Test that variables carry useExperimental: true when opted in."""
     api_request = agent_details.AgentDetailsAPIRequest(
         agent_key="agent/ostorlab/nmap", use_experimental=True
@@ -29,11 +43,13 @@ def testAgentDetailsAPIRequest_whenUseExperimentalTrue_setsTrueInVariables() -> 
     assert variables == {"agentKey": "agent/ostorlab/nmap", "useExperimental": True}
 
 
-def testAgentDetailsAPIRequest_whenCalled_queryDeclaresUseExperimentalVariable() -> (
+def testAgentDetailsAPIRequest_whenUseExperimentalTrue_sendsQueryWithUseExperimentalArg() -> (
     None
 ):
-    """Test that the GraphQL query declares and forwards the useExperimental variable."""
-    api_request = agent_details.AgentDetailsAPIRequest(agent_key="agent/ostorlab/nmap")
+    """Test that the experimental query form (with useExperimental) is sent when opted in."""
+    api_request = agent_details.AgentDetailsAPIRequest(
+        agent_key="agent/ostorlab/nmap", use_experimental=True
+    )
 
     query = api_request.query
 

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -949,8 +949,8 @@ agents:
         [
             "scan",
             "--runtime=local",
-            "--use-experimental-agents",
             "run",
+            "--use-experimental-agents",
             "-g",
             str(agent_group_yaml),
             "--install",

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -915,3 +915,51 @@ agents:
     assert len(calls) > 0
     assert calls[0][1]["version"] is None
     assert result.exit_code == 0
+
+
+def testRunScan_whenInstallAndReportingScanIdProvided_passesReportingScanIdToGetDetails(
+    mocker: plugin.MockerFixture, tmp_path: pathlib.Path
+) -> None:
+    """Test that --reporting-scan-id is threaded into agent_fetcher.get_details when installing agents."""
+    agent_group_yaml = tmp_path / "agent_group.yaml"
+    agent_group_yaml.write_text(
+        """
+kind: AgentGroup
+description: Test agent group
+agents:
+  - key: agent/ostorlab/nmap
+"""
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.runtime.LocalRuntime.can_run", return_value=True
+    )
+    mocker.patch("ostorlab.runtimes.local.runtime.LocalRuntime.install")
+    mocker.patch("ostorlab.runtimes.local.runtime.LocalRuntime.scan")
+    mocker.patch("ostorlab.runtimes.local.runtime.LocalRuntime.link_agent_group_scan")
+    mocker.patch("ostorlab.runtimes.local.runtime.LocalRuntime.link_assets_scan")
+    mocker.patch("ostorlab.cli.install_agent.install")
+    mock_get_details = mocker.patch(
+        "ostorlab.cli.agent_fetcher.get_details",
+        return_value={"versions": {"versions": [{"version": "0.4.0"}]}},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        rootcli.rootcli,
+        [
+            "scan",
+            "--runtime=local",
+            "--reporting-scan-id=42",
+            "run",
+            "-g",
+            str(agent_group_yaml),
+            "--install",
+            "ip",
+            "8.8.8.8",
+        ],
+    )
+
+    mock_get_details.assert_called_once_with(
+        "agent/ostorlab/nmap", reporting_scan_id=42
+    )
+    assert result.exit_code == 0

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -920,7 +920,7 @@ agents:
 def testRunScan_whenInstallAndUseExperimentalFlagSet_passesUseExperimentalToGetDetails(
     mocker: plugin.MockerFixture, tmp_path: pathlib.Path
 ) -> None:
-    """Test that --use-experimental-agents is threaded into agent_fetcher.get_details when installing agents."""
+    """Test that --experimental is threaded into agent_fetcher.get_details when installing agents."""
     agent_group_yaml = tmp_path / "agent_group.yaml"
     agent_group_yaml.write_text(
         """
@@ -949,7 +949,7 @@ agents:
         [
             "scan",
             "--runtime=local",
-            "--use-experimental-agents",
+            "--experimental",
             "run",
             "-g",
             str(agent_group_yaml),

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -949,8 +949,8 @@ agents:
         [
             "scan",
             "--runtime=local",
-            "run",
             "--use-experimental-agents",
+            "run",
             "-g",
             str(agent_group_yaml),
             "--install",

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -917,10 +917,10 @@ agents:
     assert result.exit_code == 0
 
 
-def testRunScan_whenInstallAndReportingScanIdProvided_passesReportingScanIdToGetDetails(
+def testRunScan_whenInstallAndUseExperimentalFlagSet_passesUseExperimentalToGetDetails(
     mocker: plugin.MockerFixture, tmp_path: pathlib.Path
 ) -> None:
-    """Test that --reporting-scan-id is threaded into agent_fetcher.get_details when installing agents."""
+    """Test that --use-experimental-agents is threaded into agent_fetcher.get_details when installing agents."""
     agent_group_yaml = tmp_path / "agent_group.yaml"
     agent_group_yaml.write_text(
         """
@@ -949,7 +949,7 @@ agents:
         [
             "scan",
             "--runtime=local",
-            "--reporting-scan-id=42",
+            "--use-experimental-agents",
             "run",
             "-g",
             str(agent_group_yaml),
@@ -960,6 +960,6 @@ agents:
     )
 
     mock_get_details.assert_called_once_with(
-        "agent/ostorlab/nmap", reporting_scan_id=42
+        "agent/ostorlab/nmap", use_experimental=True
     )
     assert result.exit_code == 0

--- a/tests/cli/test_agent_fetcher.py
+++ b/tests/cli/test_agent_fetcher.py
@@ -30,7 +30,7 @@ def testGetDetails_whenUseExperimentalNotProvided_buildsRequestWithDefaultFalse(
 
 
 def testGetDetails_whenUseExperimentalTrue_buildsRequestWithTrue() -> None:
-    """Test that get_details forwards reporting_scan_id to the API request."""
+    """Test that get_details forwards use_experimental=True to the API request."""
     with mock.patch(
         "ostorlab.cli.agent_fetcher.configuration_manager.ConfigurationManager"
     ) as mock_config_manager:

--- a/tests/cli/test_agent_fetcher.py
+++ b/tests/cli/test_agent_fetcher.py
@@ -5,6 +5,74 @@ from unittest import mock
 from ostorlab.cli import agent_fetcher
 
 
+def testGetDetails_whenNoReportingScanIdProvided_buildsRequestWithoutReportingScanId() -> (
+    None
+):
+    """Test that get_details builds the API request with reporting_scan_id=None by default."""
+    with mock.patch(
+        "ostorlab.cli.agent_fetcher.configuration_manager.ConfigurationManager"
+    ) as mock_config_manager:
+        mock_config_manager.return_value.is_authenticated = False
+        with mock.patch(
+            "ostorlab.cli.agent_fetcher.public_runner.PublicAPIRunner"
+        ) as mock_runner_cls:
+            mock_runner = mock.Mock()
+            mock_runner_cls.return_value = mock_runner
+            mock_runner.execute.return_value = {"data": {"agent": {"key": "value"}}}
+            with mock.patch(
+                "ostorlab.cli.agent_fetcher.agent_details_api.AgentDetailsAPIRequest"
+            ) as mock_request_cls:
+                agent_fetcher.get_details("agent/ostorlab/nmap")
+
+                mock_request_cls.assert_called_once_with(
+                    "agent/ostorlab/nmap", reporting_scan_id=None
+                )
+
+
+def testGetDetails_whenReportingScanIdProvided_buildsRequestWithReportingScanId() -> (
+    None
+):
+    """Test that get_details forwards reporting_scan_id to the API request."""
+    with mock.patch(
+        "ostorlab.cli.agent_fetcher.configuration_manager.ConfigurationManager"
+    ) as mock_config_manager:
+        mock_config_manager.return_value.is_authenticated = False
+        with mock.patch(
+            "ostorlab.cli.agent_fetcher.public_runner.PublicAPIRunner"
+        ) as mock_runner_cls:
+            mock_runner = mock.Mock()
+            mock_runner_cls.return_value = mock_runner
+            mock_runner.execute.return_value = {"data": {"agent": {"key": "value"}}}
+            with mock.patch(
+                "ostorlab.cli.agent_fetcher.agent_details_api.AgentDetailsAPIRequest"
+            ) as mock_request_cls:
+                agent_fetcher.get_details("agent/ostorlab/nmap", reporting_scan_id=42)
+
+                mock_request_cls.assert_called_once_with(
+                    "agent/ostorlab/nmap", reporting_scan_id=42
+                )
+
+
+def testGetDetails_whenResponseHasNoErrors_returnsAgentDetails() -> None:
+    """Test that get_details returns the agent details dict from a successful response."""
+    with mock.patch(
+        "ostorlab.cli.agent_fetcher.configuration_manager.ConfigurationManager"
+    ) as mock_config_manager:
+        mock_config_manager.return_value.is_authenticated = False
+        with mock.patch(
+            "ostorlab.cli.agent_fetcher.public_runner.PublicAPIRunner"
+        ) as mock_runner_cls:
+            mock_runner = mock.Mock()
+            mock_runner_cls.return_value = mock_runner
+            mock_runner.execute.return_value = {
+                "data": {"agent": {"key": "agent/ostorlab/nmap"}}
+            }
+
+            result = agent_fetcher.get_details("agent/ostorlab/nmap")
+
+            assert result == {"key": "agent/ostorlab/nmap"}
+
+
 def testGetContainerImage_whenExactVersionRequested_shouldReturnExactMatch() -> None:
     """Test that version matching is exact, not regex-based."""
     with mock.patch("ostorlab.cli.agent_fetcher.docker.from_env") as mock_docker:

--- a/tests/cli/test_agent_fetcher.py
+++ b/tests/cli/test_agent_fetcher.py
@@ -29,9 +29,7 @@ def testGetDetails_whenUseExperimentalNotProvided_buildsRequestWithDefaultFalse(
                 )
 
 
-def testGetDetails_whenUseExperimentalTrue_buildsRequestWithTrue() -> (
-    None
-):
+def testGetDetails_whenUseExperimentalTrue_buildsRequestWithTrue() -> None:
     """Test that get_details forwards reporting_scan_id to the API request."""
     with mock.patch(
         "ostorlab.cli.agent_fetcher.configuration_manager.ConfigurationManager"

--- a/tests/cli/test_agent_fetcher.py
+++ b/tests/cli/test_agent_fetcher.py
@@ -5,10 +5,10 @@ from unittest import mock
 from ostorlab.cli import agent_fetcher
 
 
-def testGetDetails_whenNoReportingScanIdProvided_buildsRequestWithoutReportingScanId() -> (
+def testGetDetails_whenUseExperimentalNotProvided_buildsRequestWithDefaultFalse() -> (
     None
 ):
-    """Test that get_details builds the API request with reporting_scan_id=None by default."""
+    """Test that get_details builds the API request with use_experimental=False by default."""
     with mock.patch(
         "ostorlab.cli.agent_fetcher.configuration_manager.ConfigurationManager"
     ) as mock_config_manager:
@@ -25,11 +25,11 @@ def testGetDetails_whenNoReportingScanIdProvided_buildsRequestWithoutReportingSc
                 agent_fetcher.get_details("agent/ostorlab/nmap")
 
                 mock_request_cls.assert_called_once_with(
-                    "agent/ostorlab/nmap", reporting_scan_id=None
+                    "agent/ostorlab/nmap", use_experimental=False
                 )
 
 
-def testGetDetails_whenReportingScanIdProvided_buildsRequestWithReportingScanId() -> (
+def testGetDetails_whenUseExperimentalTrue_buildsRequestWithTrue() -> (
     None
 ):
     """Test that get_details forwards reporting_scan_id to the API request."""
@@ -46,10 +46,10 @@ def testGetDetails_whenReportingScanIdProvided_buildsRequestWithReportingScanId(
             with mock.patch(
                 "ostorlab.cli.agent_fetcher.agent_details_api.AgentDetailsAPIRequest"
             ) as mock_request_cls:
-                agent_fetcher.get_details("agent/ostorlab/nmap", reporting_scan_id=42)
+                agent_fetcher.get_details("agent/ostorlab/nmap", use_experimental=True)
 
                 mock_request_cls.assert_called_once_with(
-                    "agent/ostorlab/nmap", reporting_scan_id=42
+                    "agent/ostorlab/nmap", use_experimental=True
                 )
 
 

--- a/tests/serve_app/oxo_test.py
+++ b/tests/serve_app/oxo_test.py
@@ -2331,6 +2331,7 @@ def testRunScanMutation_whenNetworkAsset_shouldRunScan(
     mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.can_run", return_value=True
     )
+    mocker.patch("ostorlab.runtimes.local.runtime.LocalRuntime.scan")
     prepare_scan_mock = mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.prepare_scan", return_value=scan
     )
@@ -2476,6 +2477,7 @@ def testRunScanMutation_whenUrl_shouldRunScan(
     mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.can_run", return_value=True
     )
+    mocker.patch("ostorlab.runtimes.local.runtime.LocalRuntime.scan")
     prepare_scan_mock = mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.prepare_scan", return_value=scan
     )
@@ -2557,6 +2559,7 @@ def testRunScanMutation_whenAndroidFile_shouldRunScan(
     mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.can_run", return_value=True
     )
+    mocker.patch("ostorlab.runtimes.local.runtime.LocalRuntime.scan")
     prepare_scan_mock = mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.prepare_scan", return_value=scan
     )
@@ -2629,6 +2632,7 @@ def testRunScanMutation_whenIosFile_shouldRunScan(
     mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.can_run", return_value=True
     )
+    mocker.patch("ostorlab.runtimes.local.runtime.LocalRuntime.scan")
     prepare_scan_mock = mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.prepare_scan", return_value=scan
     )
@@ -2701,6 +2705,7 @@ def testRunScanMutation_whenAndroidStore_shouldRunScan(
     mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.can_run", return_value=True
     )
+    mocker.patch("ostorlab.runtimes.local.runtime.LocalRuntime.scan")
     prepare_scan_mock = mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.prepare_scan", return_value=scan
     )
@@ -2773,6 +2778,7 @@ def testRunScanMutation_whenIosStore_shouldRunScan(
     mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.can_run", return_value=True
     )
+    mocker.patch("ostorlab.runtimes.local.runtime.LocalRuntime.scan")
     prepare_scan_mock = mocker.patch(
         "ostorlab.runtimes.local.runtime.LocalRuntime.prepare_scan", return_value=scan
     )


### PR DESCRIPTION
Adds the oxo-side plumbing for the experimental agent release channel: a hidden `--experimental` / `-x` boolean flag on the `scan` group, threaded through to the `Agent` GraphQL query as `useExperimental: Boolean`.

- `--experimental` / `-x` hidden flag on the `scan` group (param name `use_experimental_agents`), stored on `ctx.obj` and OR'd with `agent_group.use_experimental_agents` before being passed to `_install_agents_with_retry`.
- `AgentDetailsAPIRequest` uses a single query that always declares `$useExperimental: Boolean` and sends the variable as `True` or `False`. The server-side resolver excludes experimental versions when `False`.
- `AgentGroupDefinition.use_experimental_agents` YAML field allows per-group opt-in independently of the CLI flag.

**Tests:**
- `tests/apis/agent_details_test.py` — variables always contain `useExperimental`; `false` by default, `true` when opted in.
- `tests/cli/test_agent_fetcher.py` — `get_details` forwards `use_experimental` to the API request.
- `tests/cli/scan/run/run_test.py` — `--experimental` on the CLI reaches `agent_fetcher.get_details` during `--install`.

## Merge order
Ostorlab/ogle_reporting_engine#4957 → Ostorlab/ogle_reporting_engine#4962 → #1067 (**WE ARE HERE**) → Ostorlab/ogle_scanning_engine#648