### PR TITLE
fix: harden scan log streaming output

### DIFF
--- a/src/ostorlab/cli/scan/run/run.py
+++ b/src/ostorlab/cli/scan/run/run.py
@@ -98,7 +98,7 @@ WAIT_BETWEEN_RETRIES = 5
 )
 @click.option(
     "--timeout",
-    "-t",
+    "-T",
     type=int,
     help="Timeout for the scan in seconds",
     required=False,

--- a/src/ostorlab/runtimes/local/log_streamer.py
+++ b/src/ostorlab/runtimes/local/log_streamer.py
@@ -5,6 +5,7 @@ import time
 
 import docker.errors
 from docker.models import services as docker_service
+from rich.markup import escape
 
 from ostorlab.cli import console as cli_console
 
@@ -48,7 +49,10 @@ class _ServiceLogStream:
         for line in logs:
             if self._stop_event.is_set():
                 break
-            console.info(f"[{self._color} bold]{name}:[/] {line[:-1].decode()}")
+            log_line = line[:-1].decode()
+            console.info(
+                f"[{self._color} bold]{escape(name)}:[/] {escape(log_line)}"
+            )
 
     def stop(self) -> None:
         """Stop the log stream."""

--- a/src/ostorlab/runtimes/local/log_streamer.py
+++ b/src/ostorlab/runtimes/local/log_streamer.py
@@ -50,9 +50,7 @@ class _ServiceLogStream:
             if self._stop_event.is_set():
                 break
             log_line = line[:-1].decode()
-            console.info(
-                f"[{self._color} bold]{escape(name)}:[/] {escape(log_line)}"
-            )
+            console.info(f"[{self._color} bold]{escape(name)}:[/] {escape(log_line)}")
 
     def stop(self) -> None:
         """Stop the log stream."""

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -1,6 +1,7 @@
 """Tests for scan run command."""
 
 import pathlib
+import warnings
 
 from pytest_mock import plugin
 import httpx
@@ -28,6 +29,24 @@ def testOstorlabScanRunCLI_whenNoOptionsProvided_showsAvailableOptionsAndCommand
     assert "Commands:" in result.output
     assert "Options:" in result.output
     assert result.exit_code == 2
+
+
+def testOstorlabScanRunCLI_whenHelpRequested_doesNotWarnAboutDuplicateOptions(
+    mocker,
+) -> None:
+    """Test scan run help does not trigger click duplicate option warnings."""
+    runner = CliRunner()
+    mocker.patch("ostorlab.runtimes.local.LocalRuntime.__init__", return_value=None)
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        result = runner.invoke(rootcli.rootcli, ["scan", "run", "--help"])
+
+    assert result.exit_code == 0
+    assert all(
+        "The parameter -t is used more than once" not in str(w.message)
+        for w in caught_warnings
+    )
 
 
 def testRunScanCLI_WhenAgentsAreInvalid_ShowError(mocker):
@@ -559,9 +578,9 @@ def testScanRunCLI_whenTimeoutProvided_setsTrackerAgentTimeout(
             "scan",
             "--runtime=local",
             "run",
-            "--install",
             "--agent=agent/ostorlab/nmap",
-            "--timeout=3600",
+            "-T",
+            "3600",
             "--init-sleep=1800",
             "ip",
             "8.8.8.8",

--- a/tests/runtimes/local/log_streamer_test.py
+++ b/tests/runtimes/local/log_streamer_test.py
@@ -39,6 +39,22 @@ def testServiceLogStream_whenLogsAreAvailable_logsArePrintedToConsole(
     )
 
 
+def testServiceLogStream_whenLogLineHasRichMarkup_escapesLogLine(
+    mocker: plugin.MockerFixture, service_mock: mock.MagicMock
+) -> None:
+    """Test that log lines are escaped before being passed to rich."""
+    service_mock.logs.return_value = [b"closing tag [/] without opener\n"]
+    console_mock = mocker.patch("ostorlab.runtimes.local.log_streamer.console")
+    mocker.patch("threading.Event.is_set", side_effect=[False, True])
+
+    stream = log_streamer._ServiceLogStream(service_mock, color="red")
+    stream._stream()
+
+    console_mock.info.assert_called_once_with(
+        "[red bold]service_name:[/] closing tag \\[/] without opener"
+    )
+
+
 def testLogStream_whenStreamIsCalled_aNewThreadIsStarted(
     mocker: plugin.MockerFixture, service_mock: mock.MagicMock
 ) -> None:


### PR DESCRIPTION
Problem:

Running source-code scans exposed two CLI/runtime issues:

- Click emitted duplicate option warnings because `scan run` assigned `-t` to both `--title` and `--timeout`.
- The local log streamer passed raw Docker log lines through Rich markup parsing. If an agent log contained markup-like text such as `[/]`, Rich raised `MarkupError` and the log streaming thread crashed.

```log
ERROR: Package 'ostorlab' requires a different Python: 3.12.3 not in '>=3.13'
oxo/.venv/lib/python3.12/site-packages/click/core.py:1223: UserWarning: The parameter -t is used more than once. Remove its duplicate as parameters should be unique.
  parser = self.make_parser(ctx)
oxo/.venv/lib/python3.12/site-packages/click/core.py:1829: UserWarning: The parameter -t is used more than once. Remove its duplicate as parameters should be unique.
  rest = super().parse_args(ctx, args)
Exception in thread Thread-5 (_stream):
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "oxo/src/ostorlab/runtimes/local/log_streamer.py", line 51, in _stream
    console.info(f"[{self._color} bold]{name}:[/] {line[:-1].decode()}")
  File "oxo/src/ostorlab/cli/console.py", line 75, in info
    self._console.print(f":small_blue_diamond: {text}")
  File "oxo/.venv/lib/python3.12/site-packages/rich/console.py", line 1698, in print
    renderables = self._collect_renderables(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "oxo/.venv/lib/python3.12/site-packages/rich/console.py", line 1558, in _collect_renderables
    self.render_str(
  File "oxo/.venv/lib/python3.12/site-packages/rich/console.py", line 1448, in render_str
    rich_text = render_markup(
                ^^^^^^^^^^^^^^
  File "oxo/.venv/lib/python3.12/site-packages/rich/markup.py", line 174, in render
    raise MarkupError(
rich.errors.MarkupError: closing tag '[/]' at position 114 has nothing to close
```

Fix:

- Escape streamed Docker service names and log lines before rendering them with Rich.
- Move the timeout shorthand from `-t` to `-T`, keeping `-t` for scan titles.
- Add regression coverage for Rich markup escaping and the duplicate option warning.