### PR TITLE
feature: Add support for inject asset args

### DIFF
--- a/src/ostorlab/runtimes/lite_local/runtime.py
+++ b/src/ostorlab/runtimes/lite_local/runtime.py
@@ -195,7 +195,18 @@ class LiteLocalRuntime(runtime.Runtime):
                 raise AgentNotHealthy()
             if assets is not None:
                 console.info("Injecting assets")
-                self._inject_assets(assets=assets)
+                inject_asset_agent_settings = next(
+                    (
+                        agent
+                        for agent in agent_group_definition.agents
+                        if agent.key == ASSET_INJECTION_AGENT_DEFAULT
+                    ),
+                    None,
+                )
+                self._inject_assets(
+                    assets=assets,
+                    inject_asset_agent_settings=inject_asset_agent_settings,
+                )
         except AgentNotHealthy:
             console.error("Agent not starting")
             self.stop(self.scan_id)
@@ -270,6 +281,7 @@ class LiteLocalRuntime(runtime.Runtime):
             future_to_agent = {
                 executor.submit(self._start_agent, agent, extra_configs=[]): agent
                 for agent in agent_group_definition.agents
+                if agent.key != ASSET_INJECTION_AGENT_DEFAULT
             }
             for future in futures.as_completed(future_to_agent):
                 future.result()
@@ -344,7 +356,11 @@ class LiteLocalRuntime(runtime.Runtime):
             if service.name.startswith("agent_"):
                 yield service
 
-    def _inject_assets(self, assets: List[base_asset.Asset]):
+    def _inject_assets(
+        self,
+        assets: list[base_asset.Asset],
+        inject_asset_agent_settings: definitions.AgentSettings | None = None,
+    ):
         """Injects the scan target assets."""
 
         contents = {}
@@ -354,9 +370,11 @@ class LiteLocalRuntime(runtime.Runtime):
 
         volumes.create_volume(f"asset_{self.name}", contents)
 
-        inject_asset_agent_settings = definitions.AgentSettings(
-            key=ASSET_INJECTION_AGENT_DEFAULT, restart_policy="none"
-        )
+        if inject_asset_agent_settings is None:
+            inject_asset_agent_settings = definitions.AgentSettings(
+                key=ASSET_INJECTION_AGENT_DEFAULT, restart_policy="none"
+            )
+
         self._start_agent(
             agent=inject_asset_agent_settings,
             extra_mounts=[

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -234,7 +234,18 @@ class LocalRuntime(runtime.Runtime):
                 raise AgentNotHealthy()
 
             if assets is not None:
-                self._inject_assets(assets)
+                inject_asset_agent_settings = next(
+                    (
+                        agent
+                        for agent in agent_group_definition.agents
+                        if agent.key == ASSET_INJECTION_AGENT_DEFAULT
+                    ),
+                    None,
+                )
+                self._inject_assets(
+                    assets=assets,
+                    inject_asset_agent_settings=inject_asset_agent_settings,
+                )
             console.info("Updating scan status")
             self._update_scan_progress("IN_PROGRESS")
             console.success("Scan created successfully")
@@ -420,6 +431,7 @@ class LocalRuntime(runtime.Runtime):
             future_to_agent = {
                 executor.submit(self._start_agent, agent, extra_configs=[]): agent
                 for agent in agent_group_definition.agents
+                if agent.key != ASSET_INJECTION_AGENT_DEFAULT
             }
             for future in futures.as_completed(future_to_agent):
                 future.result()
@@ -536,7 +548,11 @@ class LocalRuntime(runtime.Runtime):
         )
         self._start_agent(agent=persist_vulnz_agent_settings, extra_configs=[])
 
-    def _inject_assets(self, assets: List[base_asset.Asset]):
+    def _inject_assets(
+        self,
+        assets: list[base_asset.Asset],
+        inject_asset_agent_settings: definitions.AgentSettings | None = None,
+    ):
         """Injects the scan target assets."""
         contents = {}
         for i, asset in enumerate(assets):
@@ -546,9 +562,11 @@ class LocalRuntime(runtime.Runtime):
 
         volumes.create_volume(f"asset_{self.name}", contents)
 
-        inject_asset_agent_settings = definitions.AgentSettings(
-            key=ASSET_INJECTION_AGENT_DEFAULT, restart_policy="none"
-        )
+        if inject_asset_agent_settings is None:
+            inject_asset_agent_settings = definitions.AgentSettings(
+                key=ASSET_INJECTION_AGENT_DEFAULT, restart_policy="none"
+            )
+
         self._start_agent(
             agent=inject_asset_agent_settings,
             extra_mounts=[

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -25,7 +25,7 @@ def testOstorlabScanRunCLI_whenNoOptionsProvided_showsAvailableOptionsAndCommand
     runner = CliRunner()
     mocker.patch("ostorlab.runtimes.local.LocalRuntime.__init__", return_value=None)
     result = runner.invoke(rootcli.rootcli, ["scan", "run"])
-    assert "Usage: rootcli scan run [OPTIONS] COMMAND [ARGS]..." in result.output
+    assert "Usage: rootcli scan run [OPTIONS] [COMMAND] [ARGS]..." in result.output
     assert "Commands:" in result.output
     assert "Options:" in result.output
     assert result.exit_code == 2

--- a/tests/runtimes/lite_local/runtime_test.py
+++ b/tests/runtimes/lite_local/runtime_test.py
@@ -11,6 +11,7 @@ from ostorlab.runtimes import definitions
 from ostorlab.runtimes.lite_local import agent_runtime
 from ostorlab.runtimes.lite_local import runtime as lite_local_runtime
 from ostorlab.utils import definitions as utils_definitions
+from ostorlab.assets import android_apk
 
 
 def container_name_mock(name):
@@ -671,3 +672,72 @@ def testLiteLocalRuntimeInit_always_setsMaxPoolSize(mocker):
         tracing_collector_url="jaeger://localhost/",
     )
     mock_from_env.assert_called_once_with(max_pool_size=100)
+
+
+@pytest.mark.docker
+def testScanInLiteLocalRuntime_whenInjectAssetAgentIsProvided_shouldUseTheProvidedAgentSettings(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Ensure if an inject_asset agent settings are passed as part of the agent group,
+    they are used instead of the default ones."""
+    mocker.patch(
+        "ostorlab.runtimes.definitions.AgentSettings.container_image",
+        return_value="agent_42_docker_image",
+        new_callable=mocker.PropertyMock,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_installed",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_sys_arch_supported",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_user_permitted", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_working", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_swarm_initialized",
+        return_value=True,
+    )
+    agent_runtime_mock = mocker.patch(
+        "ostorlab.runtimes.lite_local.agent_runtime.AgentRuntime"
+    )
+    mocker.patch(
+        "ostorlab.runtimes.lite_local.runtime.LiteLocalRuntime._are_agents_ready",
+        return_value=True,
+    )
+
+    lite_local_runtime_instance = lite_local_runtime.LiteLocalRuntime(
+        scan_id="1",
+        bus_url="bus",
+        bus_vhost="/",
+        bus_management_url="mgmt",
+        bus_exchange_topic="topic",
+        network="privnet",
+        redis_url="redis://redis",
+        tracing_collector_url="jaeger://localhost/",
+    )
+    agent_group_definition = definitions.AgentGroupDefinition(
+        agents=[
+            definitions.AgentSettings(
+                key="agent/ostorlab/inject_asset",
+                args=[utils_definitions.Arg(name="arg1", type="string", value="val1")],
+            )
+        ]
+    )
+
+    lite_local_runtime_instance.scan(
+        title="test lite local",
+        agent_group_definition=agent_group_definition,
+        assets=[android_apk.AndroidApk(content=b"APK")],
+    )
+
+    start_agent_mock_call_args = agent_runtime_mock.call_args_list
+    assert len(start_agent_mock_call_args) == 1
+    assert start_agent_mock_call_args[0].args[0].key == "agent/ostorlab/inject_asset"
+    assert start_agent_mock_call_args[0].args[0].args[0].name == "arg1"
+    assert start_agent_mock_call_args[0].args[0].args[0].value == "val1"

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -14,6 +14,7 @@ from ostorlab.assets import android_apk
 from ostorlab.runtimes import definitions
 from ostorlab.runtimes.local import runtime as local_runtime
 from ostorlab.runtimes.local.models import models
+from ostorlab.utils import definitions as utils_definitions
 
 
 @pytest.mark.skip(reason="Missing inject asset agent.")
@@ -481,3 +482,54 @@ def testLocalRuntimeInit_always_setsMaxPoolSize(mocker):
     runtime = local_runtime.LocalRuntime()
     runtime._docker_checks()
     mock_from_env.assert_any_call(max_pool_size=100)
+
+
+@pytest.mark.docker
+def testScanInLocalRuntime_whenInjectAssetAgentIsProvided_shouldUseTheProvidedAgentSettings(
+    mocker: plugin.MockerFixture, local_runtime_mocks: Any
+) -> None:
+    """Ensure if an inject_asset agent settings are passed as part of the agent group,
+    they are used instead of the default ones."""
+    mocker.patch(
+        "ostorlab.runtimes.definitions.AgentSettings.container_image",
+        return_value="agent_42_docker_image",
+        new_callable=mocker.PropertyMock,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.services.mq.LocalRabbitMQ.is_service_healthy",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.services.redis.LocalRedis.is_service_healthy",
+        return_value=True,
+    )
+    agent_runtime_mock = mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime"
+    )
+    local_runtime_instance = local_runtime.LocalRuntime(run_default_agents=False)
+    agent_group_definition = definitions.AgentGroupDefinition(
+        agents=[
+            definitions.AgentSettings(
+                key="agent/ostorlab/inject_asset",
+                args=[utils_definitions.Arg(name="arg1", type="string", value="val1")],
+            )
+        ]
+    )
+
+    local_runtime_instance.can_run(agent_group_definition=agent_group_definition)
+    local_runtime_instance.scan(
+        title="test local",
+        agent_group_definition=agent_group_definition,
+        assets=[android_apk.AndroidApk(content=b"APK")],
+    )
+
+    start_agent_mock_call_args = agent_runtime_mock.call_args_list
+    assert len(start_agent_mock_call_args) == 1
+    assert (
+        start_agent_mock_call_args[0].kwargs["agent_settings"].key
+        == "agent/ostorlab/inject_asset"
+    )
+    assert start_agent_mock_call_args[0].kwargs["agent_settings"].args[0].name == "arg1"
+    assert (
+        start_agent_mock_call_args[0].kwargs["agent_settings"].args[0].value == "val1"
+    )


### PR DESCRIPTION
feature: Add support for inject asset args

### Key changes:
Previously Inject asset was a default agent oxo starts by default , and wasn't accepting args
currently we changed the logic so we can pass args in the agentGroup like this:

the oxo command:
```
/home/aitougrram/projects/agents/oxo/.venv/bin/oxo scan run -g mouad.yaml repository --repository-url https://bitbucket.org/mouad-osto/first_repo.git --commit-hash b3bcad4 --provider gitbucket
```

the agent group:

```
agents:
- args:
  - {name: nvd_api_key, type: string, value: XXXX-XXXX}
  caps: []
  cyclic_processing_limit: 0
  depth_processing_limit: 0
  in_selectors: [v3.fingerprint.file]
  key: agent/ostorlab/osv
  replicas: 1
- args:
  - {name: api_reporting_engine_base_url, type: string, value: 'http://4399.17.0.1:8002/apis/graphql'}
  - {name: reporting_engine_api_key, type: string, value: "XXXXX.XXXX"}
  caps: []
  cyclic_processing_limit: 0
  depth_processing_limit: 0
  in_selectors: []
  key: agent/ostorlab/inject_asset  # <--- Now we can do this and it won't result duplicate inject asset agent s 
  replicas: 1
description: Agent group definition for scan XXXX
kind: AgentGroup
name: test_agent_group

```


<img width="1585" height="547" alt="Screenshot from 2026-06-26 15-37-22" src="https://github.com/user-attachments/assets/0e14fb86-d977-4f2a-90ff-e8e692361195" />
