### PR TITLE
feature: Add support for cloud_inject_asset in lite_local runtime

### DIFF
--- a/src/ostorlab/runtimes/lite_local/runtime.py
+++ b/src/ostorlab/runtimes/lite_local/runtime.py
@@ -29,7 +29,7 @@ NETWORK_PREFIX = "ostorlab_lite_local_network"
 logger = logging.getLogger(__name__)
 console = cli_console.Console(logger=logger)
 
-ASSET_INJECTION_AGENT_DEFAULT = "agent/ostorlab/inject_asset"
+ASSET_INJECTION_AGENT_DEFAULT = "agent/ostorlab/cloud_inject_asset"
 
 
 class UnhealthyService(exceptions.OstorlabError):
@@ -194,8 +194,19 @@ class LiteLocalRuntime(runtime.Runtime):
             if is_healthy is False:
                 raise AgentNotHealthy()
             if assets is not None:
+                inject_asset_agent_settings = next(
+                    (
+                        agent
+                        for agent in agent_group_definition.agents
+                        if agent.key == ASSET_INJECTION_AGENT_DEFAULT
+                    ),
+                    None,
+                )
                 console.info("Injecting assets")
-                self._inject_assets(assets=assets)
+                self._inject_assets(
+                    assets=assets,
+                    agent_settings=inject_asset_agent_settings,
+                )
         except AgentNotHealthy:
             console.error("Agent not starting")
             self.stop(self.scan_id)
@@ -270,6 +281,7 @@ class LiteLocalRuntime(runtime.Runtime):
             future_to_agent = {
                 executor.submit(self._start_agent, agent, extra_configs=[]): agent
                 for agent in agent_group_definition.agents
+                if agent.key != ASSET_INJECTION_AGENT_DEFAULT
             }
             for future in futures.as_completed(future_to_agent):
                 future.result()
@@ -344,7 +356,11 @@ class LiteLocalRuntime(runtime.Runtime):
             if service.name.startswith("agent_"):
                 yield service
 
-    def _inject_assets(self, assets: List[base_asset.Asset]):
+    def _inject_assets(
+        self,
+        assets: List[base_asset.Asset],
+        agent_settings: definitions.AgentSettings | None,
+    ):
         """Injects the scan target assets."""
 
         contents = {}
@@ -354,11 +370,12 @@ class LiteLocalRuntime(runtime.Runtime):
 
         volumes.create_volume(f"asset_{self.name}", contents)
 
-        inject_asset_agent_settings = definitions.AgentSettings(
-            key=ASSET_INJECTION_AGENT_DEFAULT, restart_policy="none"
-        )
+        if agent_settings is None:
+            agent_settings = definitions.AgentSettings(
+                key=ASSET_INJECTION_AGENT_DEFAULT, restart_policy="none"
+            )
         self._start_agent(
-            agent=inject_asset_agent_settings,
+            agent=agent_settings,
             extra_mounts=[
                 docker.types.Mount(
                     target="/asset", source=f"asset_{self.name}", type="volume"

--- a/src/ostorlab/runtimes/lite_local/runtime.py
+++ b/src/ostorlab/runtimes/lite_local/runtime.py
@@ -360,7 +360,7 @@ class LiteLocalRuntime(runtime.Runtime):
         self,
         assets: List[base_asset.Asset],
         agent_settings: definitions.AgentSettings | None,
-    )-> None:
+    ) -> None:
         """Injects the scan target assets."""
 
         contents = {}

--- a/src/ostorlab/runtimes/lite_local/runtime.py
+++ b/src/ostorlab/runtimes/lite_local/runtime.py
@@ -29,7 +29,8 @@ NETWORK_PREFIX = "ostorlab_lite_local_network"
 logger = logging.getLogger(__name__)
 console = cli_console.Console(logger=logger)
 
-ASSET_INJECTION_AGENT_DEFAULT = "agent/ostorlab/cloud_inject_asset"
+ASSET_CLOUD_INJECTION_AGENT = "agent/ostorlab/cloud_inject_asset"
+ASSET_INJECTION_AGENT_DEFAULT = "agent/ostorlab/inject_asset"
 
 
 class UnhealthyService(exceptions.OstorlabError):
@@ -198,7 +199,7 @@ class LiteLocalRuntime(runtime.Runtime):
                     (
                         agent
                         for agent in agent_group_definition.agents
-                        if agent.key == ASSET_INJECTION_AGENT_DEFAULT
+                        if agent.key == ASSET_CLOUD_INJECTION_AGENT
                     ),
                     None,
                 )
@@ -281,7 +282,7 @@ class LiteLocalRuntime(runtime.Runtime):
             future_to_agent = {
                 executor.submit(self._start_agent, agent, extra_configs=[]): agent
                 for agent in agent_group_definition.agents
-                if agent.key != ASSET_INJECTION_AGENT_DEFAULT
+                if agent.key != ASSET_CLOUD_INJECTION_AGENT
             }
             for future in futures.as_completed(future_to_agent):
                 future.result()

--- a/src/ostorlab/runtimes/lite_local/runtime.py
+++ b/src/ostorlab/runtimes/lite_local/runtime.py
@@ -360,7 +360,7 @@ class LiteLocalRuntime(runtime.Runtime):
         self,
         assets: List[base_asset.Asset],
         agent_settings: definitions.AgentSettings | None,
-    ):
+    )-> None:
         """Injects the scan target assets."""
 
         contents = {}

--- a/tests/cli/scan/run/run_test.py
+++ b/tests/cli/scan/run/run_test.py
@@ -25,7 +25,7 @@ def testOstorlabScanRunCLI_whenNoOptionsProvided_showsAvailableOptionsAndCommand
     runner = CliRunner()
     mocker.patch("ostorlab.runtimes.local.LocalRuntime.__init__", return_value=None)
     result = runner.invoke(rootcli.rootcli, ["scan", "run"])
-    assert "Usage: rootcli scan run [OPTIONS] COMMAND [ARGS]..." in result.output
+    assert "Usage: rootcli scan run [OPTIONS] [COMMAND] [ARGS]..." in result.output
     assert "Commands:" in result.output
     assert "Options:" in result.output
     assert result.exit_code == 2

--- a/tests/runtimes/lite_local/runtime_test.py
+++ b/tests/runtimes/lite_local/runtime_test.py
@@ -866,5 +866,5 @@ def testLiteLocalRuntimeInjectAssets_whenAgentSettingsNone_usesDefaultSettings(
     mock_create_volume.assert_called_once()
     mock_start_agent.assert_called_once()
     args, kwargs = mock_start_agent.call_args
-    assert kwargs["agent"].key == "agent/ostorlab/cloud_inject_asset"
+    assert kwargs["agent"].key == "agent/ostorlab/inject_asset"
     assert kwargs["agent"].restart_policy == "none"

--- a/tests/runtimes/lite_local/runtime_test.py
+++ b/tests/runtimes/lite_local/runtime_test.py
@@ -675,8 +675,8 @@ def testLiteLocalRuntimeInit_always_setsMaxPoolSize(mocker):
 
 
 def testLiteLocalRuntimeScan_whenAssetsProvidedAndAgentMissing_usesDefaultSettings(
-    mocker,
-):
+    mocker: plugin.MockerFixture,
+) -> None:
     """Test that scan calls _inject_assets with None when assets are provided but cloud_inject_asset is missing."""
     mocker.patch(
         "ostorlab.cli.docker_requirements_checker.is_docker_installed",
@@ -724,8 +724,8 @@ def testLiteLocalRuntimeScan_whenAssetsProvidedAndAgentMissing_usesDefaultSettin
 
 
 def testLiteLocalRuntimeScan_whenAssetsProvidedAndAgentPresent_callsInjectAssets(
-    mocker,
-):
+    mocker: plugin.MockerFixture,
+) -> None:
     """Test that scan calls _inject_assets when assets and cloud_inject_asset are provided."""
     mocker.patch(
         "ostorlab.cli.docker_requirements_checker.is_docker_installed",
@@ -771,7 +771,9 @@ def testLiteLocalRuntimeScan_whenAssetsProvidedAndAgentPresent_callsInjectAssets
     mock_inject.assert_called_once_with(assets=assets, agent_settings=agent_settings)
 
 
-def testLiteLocalRuntimeInjectAssets_always_createsVolumeAndStartsAgent(mocker):
+def testLiteLocalRuntimeInjectAssets_always_createsVolumeAndStartsAgent(
+    mocker: plugin.MockerFixture,
+) -> None:
     """Test that _inject_assets creates a volume and starts the agent."""
     mocker.patch(
         "ostorlab.cli.docker_requirements_checker.is_docker_installed",
@@ -819,7 +821,9 @@ def testLiteLocalRuntimeInjectAssets_always_createsVolumeAndStartsAgent(mocker):
     assert any(m["Target"] == "/asset" for m in kwargs["extra_mounts"])
 
 
-def testLiteLocalRuntimeInjectAssets_whenAgentSettingsNone_usesDefaultSettings(mocker):
+def testLiteLocalRuntimeInjectAssets_whenAgentSettingsNone_usesDefaultSettings(
+    mocker: plugin.MockerFixture,
+) -> None:
     """Test that _inject_assets uses default settings when agent_settings is None."""
     mocker.patch(
         "ostorlab.cli.docker_requirements_checker.is_docker_installed",

--- a/tests/runtimes/lite_local/runtime_test.py
+++ b/tests/runtimes/lite_local/runtime_test.py
@@ -6,6 +6,7 @@ from docker.models import services as services_model
 from pytest_mock import plugin
 
 import ostorlab
+from ostorlab.assets import ipv4
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.runtimes import definitions
 from ostorlab.runtimes.lite_local import agent_runtime
@@ -671,3 +672,195 @@ def testLiteLocalRuntimeInit_always_setsMaxPoolSize(mocker):
         tracing_collector_url="jaeger://localhost/",
     )
     mock_from_env.assert_called_once_with(max_pool_size=100)
+
+
+def testLiteLocalRuntimeScan_whenAssetsProvidedAndAgentMissing_usesDefaultSettings(
+    mocker,
+):
+    """Test that scan calls _inject_assets with None when assets are provided but cloud_inject_asset is missing."""
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_installed",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_sys_arch_supported",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_user_permitted", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_working", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_swarm_initialized",
+        return_value=True,
+    )
+    mocker.patch("docker.from_env", return_value=mocker.Mock())
+
+    runtime = lite_local_runtime.LiteLocalRuntime(
+        scan_id="test_scan",
+        bus_url="amqp://guest:guest@localhost:5672/",
+        bus_vhost="/",
+        bus_management_url="http://localhost:15672/",
+        bus_exchange_topic="ostorlab_test",
+        network="test_network",
+        redis_url="redis://localhost:6379",
+        tracing_collector_url="http://localhost:14268/api/traces",
+    )
+
+    agent_group = definitions.AgentGroupDefinition(agents=[])
+    assets = [ipv4.IPv4(host="8.8.8.8", mask="32")]
+
+    mocker.patch.object(runtime, "_start_agents")
+    mocker.patch.object(runtime, "_check_agents_healthy", return_value=True)
+    mock_inject = mocker.patch.object(runtime, "_inject_assets")
+
+    runtime.scan(title="test", agent_group_definition=agent_group, assets=assets)
+
+    mock_inject.assert_called_once()
+    _, kwargs = mock_inject.call_args
+    assert kwargs["agent_settings"] is None
+
+
+def testLiteLocalRuntimeScan_whenAssetsProvidedAndAgentPresent_callsInjectAssets(
+    mocker,
+):
+    """Test that scan calls _inject_assets when assets and cloud_inject_asset are provided."""
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_installed",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_sys_arch_supported",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_user_permitted", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_working", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_swarm_initialized",
+        return_value=True,
+    )
+    mocker.patch("docker.from_env", return_value=mocker.Mock())
+
+    runtime = lite_local_runtime.LiteLocalRuntime(
+        scan_id="test_scan",
+        bus_url="amqp://guest:guest@localhost:5672/",
+        bus_vhost="/",
+        bus_management_url="http://localhost:15672/",
+        bus_exchange_topic="ostorlab_test",
+        network="test_network",
+        redis_url="redis://localhost:6379",
+        tracing_collector_url="http://localhost:14268/api/traces",
+    )
+
+    agent_settings = definitions.AgentSettings(key="agent/ostorlab/cloud_inject_asset")
+    agent_group = definitions.AgentGroupDefinition(agents=[agent_settings])
+    assets = [ipv4.IPv4(host="8.8.8.8", mask="32")]
+
+    mocker.patch.object(runtime, "_start_agents")
+    mocker.patch.object(runtime, "_check_agents_healthy", return_value=True)
+    mock_inject = mocker.patch.object(runtime, "_inject_assets")
+
+    runtime.scan(title="test", agent_group_definition=agent_group, assets=assets)
+
+    mock_inject.assert_called_once_with(assets=assets, agent_settings=agent_settings)
+
+
+def testLiteLocalRuntimeInjectAssets_always_createsVolumeAndStartsAgent(mocker):
+    """Test that _inject_assets creates a volume and starts the agent."""
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_installed",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_sys_arch_supported",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_user_permitted", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_working", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_swarm_initialized",
+        return_value=True,
+    )
+    mocker.patch("docker.from_env", return_value=mocker.Mock())
+
+    runtime = lite_local_runtime.LiteLocalRuntime(
+        scan_id="test_scan",
+        bus_url="amqp://guest:guest@localhost:5672/",
+        bus_vhost="/",
+        bus_management_url="http://localhost:15672/",
+        bus_exchange_topic="ostorlab_test",
+        network="test_network",
+        redis_url="redis://localhost:6379",
+        tracing_collector_url="http://localhost:14268/api/traces",
+    )
+
+    agent_settings = definitions.AgentSettings(key="agent/ostorlab/cloud_inject_asset")
+    assets = [ipv4.IPv4(host="8.8.8.8", mask="32")]
+
+    mock_create_volume = mocker.patch("ostorlab.utils.volumes.create_volume")
+    mock_start_agent = mocker.patch.object(runtime, "_start_agent")
+
+    runtime._inject_assets(assets=assets, agent_settings=agent_settings)
+
+    mock_create_volume.assert_called_once()
+    mock_start_agent.assert_called_once()
+    args, kwargs = mock_start_agent.call_args
+    assert kwargs["agent"] == agent_settings
+    assert any(m["Target"] == "/asset" for m in kwargs["extra_mounts"])
+
+
+def testLiteLocalRuntimeInjectAssets_whenAgentSettingsNone_usesDefaultSettings(mocker):
+    """Test that _inject_assets uses default settings when agent_settings is None."""
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_installed",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_sys_arch_supported",
+        return_value=True,
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_user_permitted", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_docker_working", return_value=True
+    )
+    mocker.patch(
+        "ostorlab.cli.docker_requirements_checker.is_swarm_initialized",
+        return_value=True,
+    )
+    mocker.patch("docker.from_env", return_value=mocker.Mock())
+
+    runtime = lite_local_runtime.LiteLocalRuntime(
+        scan_id="test_scan",
+        bus_url="amqp://guest:guest@localhost:5672/",
+        bus_vhost="/",
+        bus_management_url="http://localhost:15672/",
+        bus_exchange_topic="ostorlab_test",
+        network="test_network",
+        redis_url="redis://localhost:6379",
+        tracing_collector_url="http://localhost:14268/api/traces",
+    )
+
+    assets = [ipv4.IPv4(host="8.8.8.8", mask="32")]
+
+    mock_create_volume = mocker.patch("ostorlab.utils.volumes.create_volume")
+    mock_start_agent = mocker.patch.object(runtime, "_start_agent")
+
+    runtime._inject_assets(assets=assets, agent_settings=None)
+
+    mock_create_volume.assert_called_once()
+    mock_start_agent.assert_called_once()
+    args, kwargs = mock_start_agent.call_args
+    assert kwargs["agent"].key == "agent/ostorlab/cloud_inject_asset"
+    assert kwargs["agent"].restart_policy == "none"


### PR DESCRIPTION
feature: Add support for cloud_inject_asset in lite_local runtime

the command I used to start a lite_local scan locally to test cloud_inject_asset
```shell

~/projects/agents/oxo/.venv/bin/oxo  scan  \
  --runtime litelocal \
  --scan-id 999 \
  --network ostorlab_lite_local_999 \
  --bus-url amqp://guest:guest@mq_999:5672/ \
  --bus-vhost / \
  --bus-management-url http://guest:guest@mq_999:15672/ \
  --bus-exchange-topic ostorlab_topic_999 \
  --redis-url redis://redis_999:6379/ \
   run \
  -g mouad.yaml repository --repository-url https://bitbucket.org/mouad-osto/first_repo.git --commit-hash b3bcad4 --provider bitbucket
```

agentgroup I used:

```yaml

agents:
- args:
  - {name: nvd_api_key, type: string, value: XXXXX-XXXX}
  caps: []
  cyclic_processing_limit: 0
  depth_processing_limit: 0
  in_selectors: [v3.fingerprint.file]
  key: agent/ostorlab/osv
  replicas: 1
- args:
  - {name: api_reporting_engine_base_url, type: string, value: 'http://4399.4399.0.1:8002/apis/graphql'}
  - {name: reporting_engine_api_key, type: string, value: "XXXXXX.XXXXXX"}
  caps: []
  cyclic_processing_limit: 0
  depth_processing_limit: 0
  in_selectors: []
  key: agent/ostorlab/cloud_inject_asset
  replicas: 1
description: Agent group definition for scan 999
kind: AgentGroup
name: test


```


Tested and Verified:


### Result :

cloud_inject_asset received the args from agent group:

<img width="1870" height="646" alt="image" src="https://github.com/user-attachments/assets/16fc5ee7-2d58-406d-a975-fc7f2254646c" />
