### PR TITLE
fix: remove codecov config

### DIFF
--- a/.github/workflows/pytest-linux.yml
+++ b/.github/workflows/pytest-linux.yml
@@ -45,10 +45,4 @@ jobs:
         RE_OXO_API_KEY: ${{ secrets.RE_OXO_API_KEY }}
       run: |
         set -o pipefail
-        pytest -m "not docker and not nats" --cov=./ --cov-report=xml:coverage.xml --cov-report=term-missing
-    - name: Upload coverage to Codecov.
-      uses: codecov/codecov-action@v4
-      with:
-        verbose: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.xml
+        pytest -m "not docker and not nats"


### PR DESCRIPTION
Removes the codecov config file and the coverage upload from the pytest workflow.