### PR TITLE
feature: Add hash_delete to AgentPersistMixin

### DIFF
--- a/src/ostorlab/agent/mixins/agent_persist_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_persist_mixin.py
@@ -179,6 +179,20 @@ class AgentPersistMixin:
         """
         return self._redis_client.hgetall(hash_name)
 
+    def hash_delete(
+        self, hash_name: Union[bytes, str], *keys: Union[bytes, str]
+    ) -> bool:
+        """Delete one or more keys from the hash hash_name.
+
+        Args:
+            hash_name: Name of the hash.
+            keys: Keys to delete from the hash.
+
+        Returns:
+            True if at least one key was deleted, False otherwise.
+        """
+        return bool(self._redis_client.hdel(hash_name, *keys))
+
     def delete(self, key: Union[bytes, str]) -> bool:
         """Delete a specific key.
 

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -102,6 +102,31 @@ async def testAgentPersistMixin_whenHashIsAdded_hashIsPersisted(
 @pytest.mark.parametrize("clean_redis_data", ["redis://localhost:6379"], indirect=True)
 @pytest.mark.asyncio
 @pytest.mark.docker
+async def testAgentPersistMixin_whenHashKeyIsDeleted_keyIsRemoved(
+    mocker, redis_service, clean_redis_data
+):
+    """Test proper deletion of one or more keys from a hash."""
+    del mocker, redis_service, clean_redis_data
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/debug", redis_url="redis://localhost:6379"
+    )
+    mixin = agent_persist_mixin.AgentPersistMixin(settings)
+
+    mixin.hash_add("hash_name", {"key1": "val1", "key2": "val2", "key3": "val3"})
+
+    assert mixin.hash_delete("hash_name", "key1") is True
+    assert mixin.hash_exists("hash_name", "key1") is False
+    assert mixin.hash_exists("hash_name", "key2") is True
+
+    assert mixin.hash_delete("hash_name", "NoneExistingKey") is False
+
+    assert mixin.hash_delete("hash_name", "key2", "key3") is True
+    assert mixin.hash_get_all("hash_name") == {}
+
+
+@pytest.mark.parametrize("clean_redis_data", ["redis://localhost:6379"], indirect=True)
+@pytest.mark.asyncio
+@pytest.mark.docker
 async def testAgentPersistMixinCheckIpRangeExist_whenIpRangeIsCovered_returnTrue(
     mocker, redis_service, clean_redis_data
 ):


### PR DESCRIPTION
## Summary
- Adds `hash_delete(hash_name, *keys)` to `AgentPersistMixin`, wrapping redis-py's `HDEL`
- Mirrors the existing `hash_add`/`hash_exists`/`hash_get`/`hash_get_all` style

Agents that correlate two paired messages (e.g. an HTTP request and its response, matched by id) park one side in a Redis hash until its partner arrives. Once correlated, there's currently no way to remove that entry -- `delete()` only removes a whole key, not a single hash field -- so entries accumulate forever and a redelivered message re-correlates and re-reports.

## Test plan
- [x] `pytest tests/agent/mixins/agent_persist_mixin_test.py -m docker` (8 passed, including the new `testAgentPersistMixin_whenHashKeyIsDeleted_keyIsRemoved`), run against a real Redis via the existing swarm-service fixture
- [x] `ruff format --check` / `ruff check` clean
- [x] `mypy` -- no new errors (3 pre-existing errors on unrelated lines, confirmed present on `main` too)