### PR TITLE
fix: correct 2FA test credential field names in ci-scan

### DIFF
--- a/src/ostorlab/apis/test_credentials_create.py
+++ b/src/ostorlab/apis/test_credentials_create.py
@@ -74,9 +74,9 @@ class TestCredentialEmail2FA(TestCredential):
         """Generate query variables."""
         return {
             "testCredentials": {
-                "email2FA": {
-                    "senderEmailAddress": self.sender_email_address,
-                    "emailAddress": self.email_address,
+                "email2fa": {
+                    "emailSender": self.sender_email_address,
+                    "email": self.email_address,
                     "password": self.password,
                 }
             }
@@ -93,8 +93,8 @@ class TestCredentialSMS2FA(TestCredential):
         """Generate query variables."""
         return {
             "testCredentials": {
-                "sms2FA": {
-                    "senderPhoneNumber": self.sender_phone_number,
+                "sms2fa": {
+                    "phoneSender": self.sender_phone_number,
                 }
             }
         }
@@ -110,8 +110,8 @@ class TestCredentialTOTP2FA(TestCredential):
         """Generate query variables."""
         return {
             "testCredentials": {
-                "totp2FA": {
-                    "totpSeed": self.totp_seed,
+                "totp2fa": {
+                    "totpSecret": self.totp_seed,
                 }
             }
         }

--- a/tests/apis/test_credentials_create_test.py
+++ b/tests/apis/test_credentials_create_test.py
@@ -9,9 +9,9 @@ def test_test_credential_email_2fa_to_variables():
     )
     expected = {
         "testCredentials": {
-            "email2FA": {
-                "senderEmailAddress": "sender@ex.com",
-                "emailAddress": "user@ex.com",
+            "email2fa": {
+                "emailSender": "sender@ex.com",
+                "email": "user@ex.com",
                 "password": "password",
             }
         }
@@ -25,8 +25,8 @@ def test_test_credential_sms_2fa_to_variables():
     )
     expected = {
         "testCredentials": {
-            "sms2FA": {
-                "senderPhoneNumber": "+123",
+            "sms2fa": {
+                "phoneSender": "+123",
             }
         }
     }
@@ -37,8 +37,8 @@ def test_test_credential_totp_2fa_to_variables():
     credential = test_credentials_create_api.TestCredentialTOTP2FA(totp_seed="123456")
     expected = {
         "testCredentials": {
-            "totp2FA": {
-                "totpSeed": "123456",
+            "totp2fa": {
+                "totpSecret": "123456",
             }
         }
     }


### PR DESCRIPTION
The `sms2fa`, `email2fa`, and `totp2fa` test credential variants sent by `ci-scan run --sms-2fa-sender`/`--email-2fa-*`/`--totp-2fa-seed` used field names that never matched the backend's GraphQL schema (`totp2FA`/`totpSeed` instead of `totp2fa`/`totpSecret`, and similarly for SMS and email), so every scan using any of those flags failed at credential creation with an "Unknown field" GraphQL error before a scan could ever be created. `loginPassword` and `custom` credentials were unaffected since their field names happened to already match.

- `TestCredentialEmail2FA.to_variables()`: `email2FA` -> `email2fa`, `senderEmailAddress` -> `emailSender`, `emailAddress` -> `email`
- `TestCredentialSMS2FA.to_variables()`: `sms2FA` -> `sms2fa`, `senderPhoneNumber` -> `phoneSender`
- `TestCredentialTOTP2FA.to_variables()`: `totp2FA` -> `totp2fa`, `totpSeed` -> `totpSecret`

**Tests:** `tests/apis/test_credentials_create_test.py` -- asserts the exact GraphQL variables dict produced for each of the three 2FA credential types.

## Reproduction against production

Before the fix:

```
oxo --api-key "<key>" ci-scan run \
  --title "totp_bug_repro" \
  --scan-profile full_scan \
  --test-credentials-login "fake@example.com" \
  --test-credentials-password "fakepassword" \
  --totp-2fa-seed "JBSWY3DPEHPK3PXP" \
  link --url https://example.com
```

```
🔺 ERROR: Could not start the scan. Response errors: Variable "$testCredentials"
got invalid value {"totp2FA": {"totpSeed": "JBSWY3DPEHPK3PXP"}}.
In field "totp2FA": Unknown field.
```

After the fix, run against a Mobile Bench org key with the same flags used against the `ios-ipa` asset (matching the original customer command):

```
oxo --api-key "<key>" ci-scan run \
  --title "totp_bug_repro_ipa" \
  --scan-profile full_scan \
  --test-credentials-login "fake@example.com" \
  --test-credentials-password "fakepassword" \
  --totp-2fa-seed "JBSWY3DPEHPK3PXP" \
  ios-ipa iGoat-Swift.ipa
```

```
🔹 Created test credentials login: fake@example.com, password: ************,
role: None, url: None, TestCredentialTOTP2FA(totp_seed='JBSWY3DPEHPK3PXP')
successfully
🔹 creating scan `totp_bug_repro_ipa` with profile `Full Scan` for
`MobileAssetType.IOS`
✔ Output: scan_id:196369
🔹 Scan created with id 196369.

<img width="1792" height="188" alt="image" src="https://github.com/user-attachments/assets/c459d9d2-e6f0-4185-a375-7eba5bdacffd" />
