### PR TITLE
feature: Add support for getting scanner api key in scanner config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,7 @@ agent =
     opentelemetry-sdk
     opentelemetry-exporter-otlp
     deprecated
+    opentelemetry-exporter-gcp-trace
     opentelemetry-resourcedetector-gcp < 1.13.0 # this is just temporary, (this line shouldn't be here but we need it because opentelemetry-exporter-gcp-trace rely on it )
 
 google-cloud-logging =

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,6 +90,7 @@ agent =
     deprecated
     opentelemetry-exporter-gcp-trace
 
+
 google-cloud-logging =
     google-cloud-logging
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ agent =
     opentelemetry-sdk
     opentelemetry-exporter-otlp
     deprecated
-    opentelemetry-exporter-gcp-trace<1.6.0
+    opentelemetry-exporter-gcp-trace
 
 google-cloud-logging =
     google-cloud-logging

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,7 @@ agent =
     opentelemetry-exporter-otlp
     deprecated
     opentelemetry-exporter-gcp-trace
+    opentelemetry-resourcedetector-gcp
 
 google-cloud-logging =
     google-cloud-logging

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ agent =
     opentelemetry-sdk
     opentelemetry-exporter-otlp
     deprecated
-    opentelemetry-exporter-gcp-trace
+    opentelemetry-resourcedetector-gcp < 1.13.0 # this is just temporary, (this line shouldn't be here but we need it because opentelemetry-exporter-gcp-trace rely on it )
 
 google-cloud-logging =
     google-cloud-logging

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,7 +90,6 @@ agent =
     deprecated
     opentelemetry-exporter-gcp-trace
 
-
 google-cloud-logging =
     google-cloud-logging
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,8 +88,7 @@ agent =
     opentelemetry-sdk
     opentelemetry-exporter-otlp
     deprecated
-    opentelemetry-exporter-gcp-trace
-    opentelemetry-resourcedetector-gcp
+    opentelemetry-exporter-gcp-trace<1.6.0
 
 google-cloud-logging =
     google-cloud-logging

--- a/src/ostorlab/apis/scan_update_state.py
+++ b/src/ostorlab/apis/scan_update_state.py
@@ -48,7 +48,7 @@ class ScanUpdateStateAPIRequest(request.APIRequest):
                     ... on HarmonyOsAppAssetType { path contentUrl }
                     ... on HarmonyOsRpkAssetType { path contentUrl }
                     ... on NetworkAssetType { networks }
-                    ... on AgentAssetType { key version gitLocation dockerLocation yamlFileLocation }
+                    ... on AgentAssetType { key agentVersion: version gitLocation dockerLocation yamlFileLocation }
                     ... on RiskAssetType { description rating target risksGroup }
                     ... on RisksAssetType { id }
                     ... on RepositoryAssetType { provider repositoryUrl commitHash }

--- a/src/ostorlab/apis/scanner_config.py
+++ b/src/ostorlab/apis/scanner_config.py
@@ -35,6 +35,7 @@ class ScannerConfigAPIRequest(request.APIRequest):
                 busUrl
                 busClusterId
                 busClientName
+                apiKey
                 subjectBusConfigs{
                     subjectBusConfigs{
                         subject

--- a/src/ostorlab/scanner/scanner_conf.py
+++ b/src/ostorlab/scanner/scanner_conf.py
@@ -1,7 +1,7 @@
 """Representations of nats configuration definitions."""
 
 import dataclasses
-from typing import Any
+from typing import Any, Optional
 
 
 @dataclasses.dataclass
@@ -33,7 +33,7 @@ class ScannerConfig:
     api_key: str | None = None
 
     @classmethod
-    def from_json(cls, config: dict[str, Any]) -> "ScannerConfig" | None:
+    def from_json(cls, config: dict[str, Any]) -> Optional["ScannerConfig"]:
         """Creates a ScannerConfig instance from a JSON configuration.
 
         Args:

--- a/src/ostorlab/scanner/scanner_conf.py
+++ b/src/ostorlab/scanner/scanner_conf.py
@@ -1,7 +1,7 @@
 """Representations of nats configuration definitions."""
 
 import dataclasses
-from typing import Dict, Any, Optional
+from typing import Any
 
 
 @dataclasses.dataclass
@@ -33,7 +33,7 @@ class ScannerConfig:
     api_key: str | None = None
 
     @classmethod
-    def from_json(cls, config: Dict[str, Any]) -> Optional["ScannerConfig"]:
+    def from_json(cls, config: dict[str, Any]) -> "ScannerConfig" | None:
         """Creates a ScannerConfig instance from a JSON configuration.
 
         Args:

--- a/src/ostorlab/scanner/scanner_conf.py
+++ b/src/ostorlab/scanner/scanner_conf.py
@@ -1,7 +1,7 @@
 """Representations of nats configuration definitions."""
 
 import dataclasses
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 
 
 @dataclasses.dataclass
@@ -29,7 +29,8 @@ class ScannerConfig:
     bus_cluster_id: str
     bus_client_name: str
     registry_conf: RegistryConfig
-    subject_bus_configs: List[SubjectBusConfigs]
+    subject_bus_configs: list[SubjectBusConfigs]
+    api_key: str | None = None
 
     @classmethod
     def from_json(cls, config: Dict[str, Any]) -> Optional["ScannerConfig"]:
@@ -76,4 +77,5 @@ class ScannerConfig:
             bus_client_name=conf.get("busClientName"),
             registry_conf=registry_conf_instance,
             subject_bus_configs=bus_configs,
+            api_key=conf.get("apiKey"),
         )

--- a/tests/apis/scanner_runner_test.py
+++ b/tests/apis/scanner_runner_test.py
@@ -87,20 +87,3 @@ def testScannerAPIRunner_whenExecuteSucceeds_returnsData() -> None:
         result = runner.execute(req)
 
     assert result == {"data": {"test": "ok"}}
-
-
-def testScannerAPIRunner_whenRequestIsJson_setsContentType() -> None:
-    """Test _sent_request sets Content-Type to application/json."""
-    runner = _make_runner()
-    req = _TestRequest()
-
-    with mock.patch.object(httpx, "Client", autospec=True) as mock_client:
-        mock_client.return_value.__enter__.return_value.post.return_value = (
-            httpx.Response(200, json={"data": {"test": "ok"}})
-        )
-        runner._sent_request(req, headers={})
-
-    call_headers = mock_client.return_value.__enter__.return_value.post.call_args[1][
-        "headers"
-    ]
-    assert call_headers["Content-Type"] == "application/json"

--- a/tests/scanner/scanner_test.py
+++ b/tests/scanner/scanner_test.py
@@ -22,6 +22,7 @@ def testScannerConfigFromJson_whenReceivingConfApiResponse_shouldCreateConfInsta
                                 "url": "https://ostorlab.store/",
                             },
                             "busUrl": "nats://localhost:4222",
+                            "apiKey": "test-api-key",
                             "busClusterId": "cluster_id",
                             "busClientName": "client_name",
                             "subjectBusConfigs": {
@@ -40,6 +41,7 @@ def testScannerConfigFromJson_whenReceivingConfApiResponse_shouldCreateConfInsta
         config=api_response_data,
     )
     assert scanner_conf_instance.bus_url == "nats://localhost:4222"
+    assert scanner_conf_instance.api_key == "test-api-key"
     assert scanner_conf_instance.bus_cluster_id == "cluster_id"
     assert scanner_conf_instance.bus_client_name == "client_name"
     assert scanner_conf_instance.registry_conf.username == "robot_account"


### PR DESCRIPTION
feature: Add support for getting scanner api key in scanner config


Note: regarding `AgentAssetType` I used `agentVersion` as alias because in graphql fields with the same name should be the same type , but in case of `version` it is int in `IPAsset` but it is string in case of `AgentAssetType` so had to make alias to differentiate 