### PR TITLE
fix: make the resourcedetector cap resolvable under uv

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,8 @@ agent =
     opentelemetry-exporter-otlp
     deprecated
     opentelemetry-exporter-gcp-trace
-    opentelemetry-resourcedetector-gcp < 1.13.0 # this is just temporary, (this line shouldn't be here but we need it because opentelemetry-exporter-gcp-trace rely on it )
+    # Cap below 1.13.0 which renamed a module opentelemetry-exporter-gcp-trace still imports; the dev floor lets uv resolve the pre-release left in range.
+    opentelemetry-resourcedetector-gcp>=1.5.0dev0,<1.13.0
 
 google-cloud-logging =
     google-cloud-logging


### PR DESCRIPTION
## What?

Changes the `opentelemetry-resourcedetector-gcp` cap in the `agent` extra from `< 1.13.0` to `>=1.5.0dev0,<1.13.0`.

## Why?

`opentelemetry-exporter-gcp-trace` (pulled by the `agent` extra) imports `opentelemetry.resourcedetector.gcp_resource_detector`. `opentelemetry-resourcedetector-gcp` 1.13.0 — its first stable release — renamed that module to `opentelemetry.resource.detector.gcp`, so importing the exporter against 1.13.0 fails with `ModuleNotFoundError: No module named 'opentelemetry.resourcedetector'`. The cap holds the resource detector below 1.13.0 until a matching exporter release imports the new path.

The existing `< 1.13.0` line does not work with `uv`, which the agents and this project install with. The only versions left in range are pre-releases (the last old-path build is `1.12.0a0`), and `uv` refuses to select a pre-release from a bare upper bound, failing resolution with `No solution found ... pre-releases weren't enabled`. Adding the `>=1.5.0dev0` floor makes the specifier carry a pre-release marker, so `uv` resolves it to `1.12.0a0` without a `--prerelease` flag. Verified with `uv pip install -e ".[agent]"`: it resolves `opentelemetry-resourcedetector-gcp` to `1.12.0a0`, the old import path is present, and `opentelemetry.exporter.cloud_trace` imports.

## Changed files

- `setup.cfg`
