### PR TITLE
fix: Remove opentelemetry-resourcedetector-gcp version pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,8 +89,6 @@ agent =
     opentelemetry-exporter-otlp
     deprecated
     opentelemetry-exporter-gcp-trace
-    # Cap below 1.13.0 which renamed a module opentelemetry-exporter-gcp-trace still imports; the dev floor lets uv resolve the pre-release left in range.
-    opentelemetry-resourcedetector-gcp>=1.5.0dev0,<1.13.0
 
 google-cloud-logging =
     google-cloud-logging


### PR DESCRIPTION
Removes the temporary version pin on `opentelemetry-resourcedetector-gcp` in `setup.cfg`.