### PR TITLE
fix: Cap setuptools version below 82

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,7 @@ agent =
     opentelemetry-exporter-otlp
     deprecated
     opentelemetry-exporter-gcp-trace
-    setuptools
+    setuptools<82
 
 google-cloud-logging =
     google-cloud-logging
@@ -97,7 +97,7 @@ google-cloud-logging =
 
 # Add here test requirements (semicolon/line-separated)
 testing =
-    setuptools
+    setuptools<82
     pytest
     pytest-cov
     pytest-asyncio


### PR DESCRIPTION
Cap setuptools version (<82) in setup.cfg for agent and testing requirements.