### PR TITLE
fix: add apischema support to risks

### DIFF
--- a/src/ostorlab/agent/schema/target_group_schema.json
+++ b/src/ostorlab/agent/schema/target_group_schema.json
@@ -272,6 +272,9 @@
         "link": {
           "$ref": "#/CustomTypes/linkType"
         },
+        "apiSchema": {
+          "$ref": "#/CustomTypes/apiSchemaType"
+        },
         "androidStore": {
           "$ref": "#/CustomTypes/androidStoreType"
         },

--- a/src/ostorlab/runtimes/definitions.py
+++ b/src/ostorlab/runtimes/definitions.py
@@ -42,6 +42,7 @@ _RISK_TARGET_KEYS = (
     "ip",
     "domain",
     "link",
+    "apiSchema",
     "androidStore",
     "iosStore",
     "androidApkFile",
@@ -836,6 +837,17 @@ def _parse_risk_asset(risk_entry: dict[str, Any]) -> risk_asset.Risk:
         risk_kwargs["link"] = link_asset.Link(
             url=_resolve_risk_target_field(risk_entry, "link", "url"),
             method=risk_entry["link"].get("method") or "GET",
+        )
+
+    if risk_entry.get("apiSchema") is not None:
+        parsed_file = _parse_file_asset(risk_entry["apiSchema"])
+        risk_kwargs["api_schema"] = api_schema_asset.ApiSchema(
+            endpoint_url=_resolve_risk_target_field(
+                risk_entry, "apiSchema", "endpoint_url"
+            ),
+            content=parsed_file.content if parsed_file is not None else None,
+            content_url=parsed_file.url if parsed_file is not None else None,
+            schema_type=risk_entry["apiSchema"].get("schema_type"),
         )
 
     if risk_entry.get("androidStore") is not None:

--- a/tests/runtimes/definitions_test.py
+++ b/tests/runtimes/definitions_test.py
@@ -708,7 +708,9 @@ assets:
     )
 
 
-def testAssetGroupDefinitionFromYaml_whenRiskEmbedsApiSchema_returnsRiskWithApiSchema():
+def testAssetGroupDefinitionFromYaml_whenRiskEmbedsApiSchema_returnsRiskWithApiSchema() -> (
+    None
+):
     """Tests parsing a risk asset embedding an api schema target."""
     valid_yaml = """
 description: Risk with api schema
@@ -734,7 +736,9 @@ assets:
     assert isinstance(asset_group_def.targets[0].to_proto(), bytes)
 
 
-def testAssetGroupDefinitionFromYaml_whenRiskApiSchemaHasNoEndpointUrl_raisesValidationError():
+def testAssetGroupDefinitionFromYaml_whenRiskApiSchemaHasNoEndpointUrl_raisesValidationError() -> (
+    None
+):
     """Tests that an api schema target without an endpoint url is rejected by the target
     group schema instead of building a risk whose target carries no endpoint."""
     invalid_yaml = """

--- a/tests/runtimes/definitions_test.py
+++ b/tests/runtimes/definitions_test.py
@@ -708,6 +708,54 @@ assets:
     )
 
 
+def testAssetGroupDefinitionFromYaml_whenRiskEmbedsApiSchema_returnsRiskWithApiSchema():
+    """Tests parsing a risk asset embedding an api schema target."""
+    valid_yaml = """
+description: Risk with api schema
+kind: targetGroup
+name: risk_scan
+assets:
+  risk:
+      - severity: HIGH
+        description: Unauthenticated API operation
+        apiSchema:
+            url: https://example.com/openapi.json
+            endpoint_url: https://example.com/api/v1
+            schema_type: openapi
+"""
+
+    asset_group_def = definitions.AssetsDefinition.from_yaml(io.StringIO(valid_yaml))
+
+    assert asset_group_def.targets[0].api_schema == api_schema_asset.ApiSchema(
+        endpoint_url="https://example.com/api/v1",
+        content_url="https://example.com/openapi.json",
+        schema_type="openapi",
+    )
+    assert isinstance(asset_group_def.targets[0].to_proto(), bytes)
+
+
+def testAssetGroupDefinitionFromYaml_whenRiskApiSchemaHasNoEndpointUrl_raisesValidationError():
+    """Tests that an api schema target without an endpoint url is rejected by the target
+    group schema instead of building a risk whose target carries no endpoint."""
+    invalid_yaml = """
+description: Risk with an incomplete api schema
+kind: targetGroup
+name: risk_scan
+assets:
+  risk:
+      - severity: HIGH
+        description: Unauthenticated API operation
+        apiSchema:
+            url: https://example.com/openapi.json
+"""
+
+    with pytest.raises(
+        validator.ValidationError,
+        match="'endpoint_url' is a required property",
+    ):
+        definitions.AssetsDefinition.from_yaml(io.StringIO(invalid_yaml))
+
+
 def testAssetGroupDefinitionFromYaml_whenRiskEmbedsAndroidStore_returnsRiskWithAndroidStore():
     """Tests parsing a risk asset embedding an android store target."""
     valid_yaml = """


### PR DESCRIPTION
A risk entry in a target group YAML can embed a target (ip, domain, link, stores, app files, repository…), but apiSchema was never wired in:

- it is missing from _RISK_TARGET_KEYS, so it doesn't count toward the "at most one target" check;
- _parse_risk_asset has no branch reading it;
- riskType in target_group_schema.json doesn't declare it, and the type doesn't set additionalProperties: false.

The three combine into a silent failure: a target group carrying risk: [{severity, description, apiSchema: {...}}] validates cleanly, then produces a Risk with no target at all — the agents receive a risk with an empty proto oneof and no endpoint to test. No exception, no log line.