### PR TITLE
fix: Add scanner dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install --upgrade pip
 RUN pip install .[google-cloud-logging] --prefix=/install
 RUN pip install .[agent] --prefix=/install
 RUN pip install .[serve] --prefix=/install
+RUN pip install .[scanner] --prefix=/install
 FROM base
 COPY --from=builder /install /usr/local
 ENTRYPOINT ["ostorlab"]


### PR DESCRIPTION
psuitil could not be resolved in oxo container because it was not installed
<img width="1336" height="349" alt="Screenshot from 2026-07-27 18-58-38" src="https://github.com/user-attachments/assets/45b223ec-4657-4b46-842e-424b8f5e62ae" />
