### PR TITLE
fix: make psutil a core dependency instead of a scanner extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ install_requires =
     py-ubjson
     nats-py
     pyaxmlparser
+    psutil
 
 [options.packages.find]
 where = src
@@ -106,7 +107,6 @@ testing =
     pytest-httpx==0.30.0
 
 scanner =
-    psutil
     python-daemon
 
 serve =


### PR DESCRIPTION
Moves `psutil` from the optional `scanner` extra into the core `install_requires`.
