### PR TITLE
fix: accept a --provider flag for the risk command's repository target

### DIFF
--- a/src/ostorlab/cli/scan/run/assets/risk.py
+++ b/src/ostorlab/cli/scan/run/assets/risk.py
@@ -268,6 +268,11 @@ def risk_cli(
             "Provide --provider together with --repository-url and --commit-hash."
         )
         raise click.exceptions.Exit(2)
+    if repository_url is None and provider is not None:
+        console.error(
+            "Provide --repository-url and --commit-hash together with --provider."
+        )
+        raise click.exceptions.Exit(2)
     if repository_archive_file is not None and repository_archive_url is not None:
         console.error(
             "Provide either --repository-archive or --repository-archive-url, not both."

--- a/src/ostorlab/cli/scan/run/assets/risk.py
+++ b/src/ostorlab/cli/scan/run/assets/risk.py
@@ -179,6 +179,16 @@ _RISK_RATINGS = [
     help="Commit hash for the source code repository.",
 )
 @click.option(
+    "--provider",
+    required=False,
+    default=None,
+    type=click.Choice(
+        ["github", "gitlab", "azure", "bitbucket", "git"],
+        case_sensitive=False,
+    ),
+    help="Provider hosting the source code repository the risk applies to.",
+)
+@click.option(
     "--repository-archive",
     "repository_archive_file",
     type=click.File(mode="rb"),
@@ -218,6 +228,7 @@ def risk_cli(
     api_schema_headers: tuple,
     repository_url: str | None,
     commit_hash: str | None,
+    provider: str | None,
     repository_archive_file: io.RawIOBase | None,
     repository_archive_url: str | None,
 ) -> None:
@@ -225,7 +236,7 @@ def risk_cli(
     Example:\n
         - oxo scan run --agent=agent/ostorlab/nmap risk --severity HIGH --description "Server exposed" --ip 8.8.8.8\n
         - oxo scan run --agent=agent/ostorlab/nmap risk --severity HIGH --description-file report.txt --ip 8.8.8.8\n
-        - oxo scan run --agent=agent/ostorlab/nmap risk --severity HIGH --description "Hardcoded secret" --repository-url https://github.com/org/repo --commit-hash abc123\n
+        - oxo scan run --agent=agent/ostorlab/nmap risk --severity HIGH --description "Hardcoded secret" --repository-url https://github.com/org/repo --commit-hash abc123 --provider github\n
         - oxo scan run --agent=agent/ostorlab/nmap risk --severity HIGH --description "Hardcoded secret" --repository-archive-url https://example.com/repo.zip
     """
     if description is None and description_file is None:
@@ -251,6 +262,11 @@ def risk_cli(
         raise click.exceptions.Exit(2)
     if (repository_url is None) != (commit_hash is None):
         console.error("Provide both --repository-url and --commit-hash together.")
+        raise click.exceptions.Exit(2)
+    if repository_url is not None and provider is None:
+        console.error(
+            "Provide --provider together with --repository-url and --commit-hash."
+        )
         raise click.exceptions.Exit(2)
     if repository_archive_file is not None and repository_archive_url is not None:
         console.error(
@@ -360,10 +376,11 @@ def risk_cli(
             schema_dict["extra_headers"] = parsed_schema_headers
         risk_kwargs["api_schema"] = schema_dict
 
-    if repository_url is not None and commit_hash is not None:
+    if repository_url is not None and commit_hash is not None and provider is not None:
         risk_kwargs["repository"] = {
             "repository_url": repository_url,
             "commit_hash": commit_hash,
+            "provider": provider.upper(),
         }
 
     if repository_archive_file is not None:

--- a/tests/cli/scan/run/assets/risk_test.py
+++ b/tests/cli/scan/run/assets/risk_test.py
@@ -230,6 +230,30 @@ def testScanRunRisk_whenRepositoryProvidedWithoutProvider_shouldExitWithError(
     )
 
 
+def testScanRunRisk_whenProviderProvidedWithoutRepository_shouldExitWithError(
+    scan_run_cli_runner: testing.CliRunner,
+) -> None:
+    """Test oxo scan run risk command rejects --provider given without a repository."""
+    result = scan_run_cli_runner.invoke(
+        rootcli.rootcli,
+        [
+            "scan",
+            "run",
+            "--agent=agent1",
+            "risk",
+            "--severity=LOW",
+            "--description=Repository risk",
+            "--provider=github",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert (
+        "Provide --repository-url and --commit-hash together with --provider."
+        in result.output
+    )
+
+
 def testScanRunRisk_whenRuntimeCannotRun_shouldExitWithError(
     mocker: pytest_mock.MockerFixture,
 ) -> None:

--- a/tests/cli/scan/run/assets/risk_test.py
+++ b/tests/cli/scan/run/assets/risk_test.py
@@ -152,7 +152,7 @@ def testScanRunRisk_whenRepositoryProvided_shouldCallScanWithRiskAssetContaining
     scan_run_cli_runner: testing.CliRunner,
     mocker: pytest_mock.MockerFixture,
 ) -> None:
-    """Test oxo scan run risk command with repository URL and commit hash."""
+    """Test oxo scan run risk command with repository URL, commit hash, and provider."""
     scan_mocked = mocker.patch(
         "ostorlab.runtimes.local.LocalRuntime.scan", return_value=None
     )
@@ -168,6 +168,7 @@ def testScanRunRisk_whenRepositoryProvided_shouldCallScanWithRiskAssetContaining
             "--description=Repository risk",
             "--repository-url=https://github.com/org/repo.git",
             "--commit-hash=a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+            "--provider=github",
         ],
     )
 
@@ -179,6 +180,7 @@ def testScanRunRisk_whenRepositoryProvided_shouldCallScanWithRiskAssetContaining
     assert assets[0].repository == {
         "repository_url": "https://github.com/org/repo.git",
         "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "provider": "GITHUB",
     }
 
 
@@ -201,6 +203,31 @@ def testScanRunRisk_whenRepositoryIncomplete_shouldExitWithError(
 
     assert result.exit_code == 2
     assert "Provide both --repository-url and --commit-hash together." in result.output
+
+
+def testScanRunRisk_whenRepositoryProvidedWithoutProvider_shouldExitWithError(
+    scan_run_cli_runner: testing.CliRunner,
+) -> None:
+    """Test oxo scan run risk command requires --provider alongside repository URL and commit hash."""
+    result = scan_run_cli_runner.invoke(
+        rootcli.rootcli,
+        [
+            "scan",
+            "run",
+            "--agent=agent1",
+            "risk",
+            "--severity=LOW",
+            "--description=Repository risk",
+            "--repository-url=https://github.com/org/repo.git",
+            "--commit-hash=a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert (
+        "Provide --provider together with --repository-url and --commit-hash."
+        in result.output
+    )
 
 
 def testScanRunRisk_whenRuntimeCannotRun_shouldExitWithError(


### PR DESCRIPTION
## Summary
The risk command's repository target (--repository-url/--commit-hash) never carried a provider, even though the standalone repository command already requires one. Adds a --provider option (same choices as the repository command), now required alongside --repository-url/--commit-hash, and included in the resulting risk asset's repository field.