### PR TITLE
fix: add API key support to ScannerStateReporter and update tests

### DIFF
--- a/src/ostorlab/cli/scanner/scanner.py
+++ b/src/ostorlab/cli/scanner/scanner.py
@@ -125,7 +125,10 @@ def scanner(
     import daemon as dm
 
     state_reporter = scanner_state_reporter.ScannerStateReporter(
-        scanner_id=scanner_id, hostname=socket.gethostname(), ip=ip.get_ip()
+        scanner_id=scanner_id,
+        hostname=socket.gethostname(),
+        ip=ip.get_ip(),
+        reporting_engine_api_key=api_key,
     )
     nb_parallel_scans = parallel
     processes = []

--- a/src/ostorlab/utils/scanner_state_reporter.py
+++ b/src/ostorlab/utils/scanner_state_reporter.py
@@ -13,11 +13,13 @@ class ScannerStateReporter:
         scanner_id: str,
         hostname: str,
         ip: str,
+        reporting_engine_api_key: str | None = None,
     ):
         self._scanner_id = scanner_id
         self.scan_id = None
         self._hostname = hostname
         self._ip = ip
+        self._reporting_engine_api_key = reporting_engine_api_key
 
     @property
     def scanner_id(self) -> str:
@@ -56,7 +58,9 @@ class ScannerStateReporter:
         return state
 
     def _report_state(self, state: definitions.ScannerState) -> None:
-        runner = authenticated_runner.AuthenticatedAPIRunner()
+        runner = authenticated_runner.AuthenticatedAPIRunner(
+            api_key=self._reporting_engine_api_key
+        )
         _ = runner.execute(add_scanner_state.AddScannerStateAPIRequest(state=state))
 
     def report(self) -> None:

--- a/tests/cli/scanner/scanner_test.py
+++ b/tests/cli/scanner/scanner_test.py
@@ -67,6 +67,43 @@ def testScannerCommandInvocation_whenDaemonCommandIsDisabled_runsConnection(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def testScannerCommandInvocation_whenApiKeyProvided_passesItToStateReporter(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """The state reporter must authenticate RE requests with the CLI API key."""
+    mocker.patch.object(scanner_cli, "_configure_file_logging")
+    mocker.patch(
+        "ostorlab.cli.scanner.scanner.start_scanner",
+        return_value=None,
+    )
+    mocker.patch("multiprocessing.Process")
+    state_reporter_mock = mocker.patch(
+        "ostorlab.cli.scanner.scanner.scanner_state_reporter.ScannerStateReporter"
+    )
+
+    runner = click_testing.CliRunner()
+    result = runner.invoke(
+        rootcli.rootcli,
+        [
+            "--api-key",
+            "reporting-engine-api-key",
+            "scanner",
+            "--no-daemon",
+            "--scanner-id",
+            "11226DS",
+        ],
+    )
+
+    assert result.exit_code == 0
+    state_reporter_mock.assert_called_once_with(
+        scanner_id="11226DS",
+        hostname=mocker.ANY,
+        ip=mocker.ANY,
+        reporting_engine_api_key="reporting-engine-api-key",
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def testScannerCommandInvocation_whenParallelScanNumberIsGiven_shouldCreateCorrespondingProcesses(
     mocker: plugin.MockerFixture,
 ) -> None:

--- a/tests/utils/scanner_state_reporter_test.py
+++ b/tests/utils/scanner_state_reporter_test.py
@@ -20,8 +20,8 @@ def testReportMethod_whenCalled_updateValuesCorrectly(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     """Test the report method to ensure that the values filled from the private capture_state method are correct."""
-    mocker.patch(
-        "ostorlab.apis.runners.authenticated_runner.AuthenticatedAPIRunner.execute"
+    runner_mock = mocker.patch(
+        "ostorlab.apis.runners.authenticated_runner.AuthenticatedAPIRunner"
     )
     mocker.patch("psutil.cpu_percent", return_value=10)
     mocker.patch("psutil.cpu_count", return_value=10)
@@ -43,13 +43,18 @@ def testReportMethod_whenCalled_updateValuesCorrectly(
         total_disk=100,
     )
     report = scanner_state_reporter.ScannerStateReporter(
-        scanner_id="GGBD-DJJD-DKJK-DJDD", hostname="", ip=""
+        scanner_id="GGBD-DJJD-DKJK-DJDD",
+        hostname="",
+        ip="",
+        reporting_engine_api_key="reporting-engine-api-key",
     )
     report.scan_id = 1
     report.errors = ""
 
     report.report()
 
+    runner_mock.assert_called_once_with(api_key="reporting-engine-api-key")
+    runner_mock.return_value.execute.assert_called_once()
     assert api_request_mock.call_args.kwargs["state"] == state
 
 


### PR DESCRIPTION
## Issue

OXO successfully fetched the scanner configuration and started scans, but reporting the scanner state through `addScannerState` failed with `401 Unauthorized`.

## Cause

The Reporting Engine API key was used to fetch `ScannerConfig`, but it was not passed to `ScannerStateReporter`. Consequently, the reporter created an unauthenticated API client in the scanner child process.

This is separate from `ScannerConfig.api_key`, which authenticates scan polling against the Scanning Engine.

## Fix

Propagate the existing Reporting Engine organization API key to `ScannerStateReporter` and use it when calling `addScannerState`.

No additional API key or infrastructure configuration is required.