### PR TITLE
fix: add support for GCP logging credentials in scanner processes

### DIFF
--- a/src/ostorlab/cli/scanner/scanner.py
+++ b/src/ostorlab/cli/scanner/scanner.py
@@ -117,6 +117,7 @@ def scanner(
         raise click.exceptions.Exit(2)
 
     api_key = config_manager.ConfigurationManager().api_key or ctx.obj.get("api_key")
+    gcp_logging_credential = ctx.obj.get("gcp_logging_credential")
     scanner_log_file = log_file if persist_logs is True else None
     scanner_log_level = getattr(logging, log_level.upper())
     _configure_file_logging(scanner_log_file, scanner_log_level)
@@ -139,6 +140,7 @@ def scanner(
                 state_reporter,
                 scanner_log_file,
                 scanner_log_level,
+                gcp_logging_credential,
             ),
         )
         process.start()
@@ -159,6 +161,7 @@ def start_scanner(
     state_reporter: scanner_state_reporter.ScannerStateReporter,
     log_file: str | None = None,
     log_level: int = logging.INFO,
+    gcp_logging_credential: str | None = None,
 ) -> None:
     """Run subscription to nats in event loop.
 
@@ -168,6 +171,7 @@ def start_scanner(
         state_reporter: instance responsible for reporting the scanner state.
         log_file: Optional path to persist scanner logs.
         log_level: Logging level used for persisted scanner logs.
+        gcp_logging_credential: GCP Logging JSON credentials for agent containers.
     """
     _configure_file_logging(log_file, log_level)
     if api_key is None:
@@ -184,4 +188,5 @@ def start_scanner(
         api_key=api_key,
         scanner_id=scanner_id,
         state_reporter=state_reporter,
+        gcp_logging_credential=gcp_logging_credential,
     )

--- a/src/ostorlab/cli/scanner/scanner.py
+++ b/src/ostorlab/cli/scanner/scanner.py
@@ -117,6 +117,7 @@ def scanner(
         raise click.exceptions.Exit(2)
 
     api_key = config_manager.ConfigurationManager().api_key or ctx.obj.get("api_key")
+    gcp_logging_credential = ctx.obj.get("gcp_logging_credential")
     scanner_log_file = log_file if persist_logs is True else None
     scanner_log_level = getattr(logging, log_level.upper())
     _configure_file_logging(scanner_log_file, scanner_log_level)
@@ -142,6 +143,7 @@ def scanner(
                 state_reporter,
                 scanner_log_file,
                 scanner_log_level,
+                gcp_logging_credential,
             ),
         )
         process.start()
@@ -162,6 +164,7 @@ def start_scanner(
     state_reporter: scanner_state_reporter.ScannerStateReporter,
     log_file: str | None = None,
     log_level: int = logging.INFO,
+    gcp_logging_credential: str | None = None,
 ) -> None:
     """Run subscription to nats in event loop.
 
@@ -171,6 +174,7 @@ def start_scanner(
         state_reporter: instance responsible for reporting the scanner state.
         log_file: Optional path to persist scanner logs.
         log_level: Logging level used for persisted scanner logs.
+        gcp_logging_credential: GCP Logging JSON credentials for agent containers.
     """
     _configure_file_logging(log_file, log_level)
     if api_key is None:
@@ -187,4 +191,5 @@ def start_scanner(
         api_key=api_key,
         scanner_id=scanner_id,
         state_reporter=state_reporter,
+        gcp_logging_credential=gcp_logging_credential,
     )

--- a/src/ostorlab/scanner/callbacks.py
+++ b/src/ostorlab/scanner/callbacks.py
@@ -348,6 +348,7 @@ def start_scan(
     request: dict[str, Any],
     state_reporter: scanner_state_reporter.ScannerStateReporter,
     api_key: str | None = None,
+    gcp_logging_credential: str | None = None,
 ) -> str | None:
     """Responsible for triggering an Ostorlab scan, after receiving a scan from the API.
 
@@ -355,6 +356,7 @@ def start_scan(
         request: API response data for the scan.
         state_reporter: State reporter instance responsible for sending current state of the scanner.
         api_key: Optional api key to fetch short-lived download tokens for agent images.
+        gcp_logging_credential: GCP Logging JSON credentials for agent containers.
     """
     logger.debug("Triggering scan after receiving scan from API")
     with contextlib.closing(_connect_containers_registry()) as docker_client:
@@ -370,7 +372,10 @@ def start_scan(
         )
 
         runtime_instance = registry.select_runtime(
-            runtime_type="local", scan_id=str(scan_id), run_default_agents=False
+            runtime_type="local",
+            scan_id=str(scan_id),
+            run_default_agents=False,
+            gcp_logging_credential=gcp_logging_credential,
         )
 
         if (

--- a/src/ostorlab/scanner/scan_handler.py
+++ b/src/ostorlab/scanner/scan_handler.py
@@ -31,9 +31,11 @@ class ScanHandler:
         state_reporter: scanner_state_reporter.ScannerStateReporter,
         scan_resource_requirements: dict[str, scanner_conf.ScanResourceRequirements]
         | None = None,
+        gcp_logging_credential: str | None = None,
     ):
         self._state_reporter = state_reporter
         self._scan_resource_requirements = scan_resource_requirements or {}
+        self._gcp_logging_credential = gcp_logging_credential
         self._docker_client = docker.from_env()
 
     def close(self) -> None:
@@ -198,6 +200,7 @@ class ScanHandler:
                 request=reserved_scan,
                 state_reporter=self._state_reporter,
                 api_key=api_key,
+                gcp_logging_credential=self._gcp_logging_credential,
             )
             if started_scan_id is None:
                 logger.warning(
@@ -257,6 +260,7 @@ def start_scan_loop(
     api_key: str | None,
     scanner_id: str,
     state_reporter: scanner_state_reporter.ScannerStateReporter,
+    gcp_logging_credential: str | None = None,
 ) -> None:
     """Fetching the scanner configuration and starting the API polling loop.
 
@@ -264,6 +268,7 @@ def start_scan_loop(
         api_key: The key to connect to ostorlab.
         scanner_id: The scanner identifier.
         state_reporter: instance responsible for reporting the scanner state.
+        gcp_logging_credential: GCP Logging JSON credentials for agent containers.
     """
     logger.info("Fetching scanner configuration.")
     runner = authenticated_runner.AuthenticatedAPIRunner(api_key=api_key)
@@ -282,6 +287,7 @@ def start_scan_loop(
     scan_handler = ScanHandler(
         state_reporter=state_reporter,
         scan_resource_requirements=config.scan_resource_requirements,
+        gcp_logging_credential=gcp_logging_credential,
     )
     try:
         scan_handler.handle_messages(runner=s_runner, api_key=api_key)

--- a/tests/cli/scanner/scanner_test.py
+++ b/tests/cli/scanner/scanner_test.py
@@ -67,6 +67,38 @@ def testScannerCommandInvocation_whenDaemonCommandIsDisabled_runsConnection(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def testScannerCommandInvocation_whenGcpCredentialProvided_forwardsItToProcess(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Forward GCP logging credentials to every scanner process."""
+    mocker.patch.object(scanner_cli, "_configure_file_logging")
+    create_process_mock = mocker.patch("multiprocessing.Process")
+    mocker.patch(
+        "ostorlab.cli.rootcli.open",
+        mocker.mock_open(read_data='{"project_id": "test-project"}'),
+    )
+    mocker.patch("google.oauth2.service_account.Credentials.from_service_account_info")
+    mocker.patch("google.cloud.logging.Client")
+
+    runner = click_testing.CliRunner()
+    result = runner.invoke(
+        rootcli.rootcli,
+        [
+            "--gcp-logging-credential",
+            __file__,
+            "scanner",
+            "--no-daemon",
+            "--scanner-id",
+            "11226DS",
+        ],
+    )
+
+    assert result.exit_code == 0
+    process_args = create_process_mock.call_args.kwargs["args"]
+    assert process_args[-1] == '{"project_id": "test-project"}'
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def testScannerCommandInvocation_whenParallelScanNumberIsGiven_shouldCreateCorrespondingProcesses(
     mocker: plugin.MockerFixture,
 ) -> None:
@@ -172,7 +204,7 @@ def testScannerCommandInvocation_whenPersistLogsIsProvided_passesLogFileToWorker
 
     assert result.exit_code == 0
     assert create_scan_process_mock.call_count == 1
-    _, _, _, scanner_log_file, scanner_log_level = (
+    _, _, _, scanner_log_file, scanner_log_level, _ = (
         create_scan_process_mock.call_args.kwargs["args"]
     )
     assert scanner_log_file == str(log_file)
@@ -210,7 +242,7 @@ def testScannerCommandInvocation_whenLogLevelIsProvided_passesLogLevelToWorker(
 
     assert result.exit_code == 0
     assert create_scan_process_mock.call_count == 1
-    _, _, _, scanner_log_file, scanner_log_level = (
+    _, _, _, scanner_log_file, scanner_log_level, _ = (
         create_scan_process_mock.call_args.kwargs["args"]
     )
     assert scanner_log_file == str(log_file)

--- a/tests/cli/scanner/scanner_test.py
+++ b/tests/cli/scanner/scanner_test.py
@@ -104,6 +104,38 @@ def testScannerCommandInvocation_whenApiKeyProvided_passesItToStateReporter(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def testScannerCommandInvocation_whenGcpCredentialProvided_forwardsItToProcess(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Forward GCP logging credentials to every scanner process."""
+    mocker.patch.object(scanner_cli, "_configure_file_logging")
+    create_process_mock = mocker.patch("multiprocessing.Process")
+    mocker.patch(
+        "ostorlab.cli.rootcli.open",
+        mocker.mock_open(read_data='{"project_id": "test-project"}'),
+    )
+    mocker.patch("google.oauth2.service_account.Credentials.from_service_account_info")
+    mocker.patch("google.cloud.logging.Client")
+
+    runner = click_testing.CliRunner()
+    result = runner.invoke(
+        rootcli.rootcli,
+        [
+            "--gcp-logging-credential",
+            __file__,
+            "scanner",
+            "--no-daemon",
+            "--scanner-id",
+            "11226DS",
+        ],
+    )
+
+    assert result.exit_code == 0
+    process_args = create_process_mock.call_args.kwargs["args"]
+    assert process_args[-1] == '{"project_id": "test-project"}'
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def testScannerCommandInvocation_whenParallelScanNumberIsGiven_shouldCreateCorrespondingProcesses(
     mocker: plugin.MockerFixture,
 ) -> None:
@@ -209,7 +241,7 @@ def testScannerCommandInvocation_whenPersistLogsIsProvided_passesLogFileToWorker
 
     assert result.exit_code == 0
     assert create_scan_process_mock.call_count == 1
-    _, _, _, scanner_log_file, scanner_log_level = (
+    _, _, _, scanner_log_file, scanner_log_level, _ = (
         create_scan_process_mock.call_args.kwargs["args"]
     )
     assert scanner_log_file == str(log_file)
@@ -247,7 +279,7 @@ def testScannerCommandInvocation_whenLogLevelIsProvided_passesLogLevelToWorker(
 
     assert result.exit_code == 0
     assert create_scan_process_mock.call_count == 1
-    _, _, _, scanner_log_file, scanner_log_level = (
+    _, _, _, scanner_log_file, scanner_log_level, _ = (
         create_scan_process_mock.call_args.kwargs["args"]
     )
     assert scanner_log_file == str(log_file)

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -70,6 +70,45 @@ def testExtractAssets_whenApkAsset_shouldReturnCorrectAsset(
     assert apk_asset.content_url is None
 
 
+def testStartScan_whenGcpCredentialProvided_forwardsItToLocalRuntime(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Forward GCP logging credentials to the local runtime."""
+    reserved_scan = {
+        "id": 42,
+        "agentGroup": {
+            "key": "agentgroup/ostorlab/agent_group42",
+            "agents": [{"key": "agent/ostorlab/dummy"}],
+        },
+        "asset": {
+            "__typename": "AndroidApkAssetType",
+            "content": base64.b64encode(b"dummy_apk").decode(),
+        },
+    }
+    mocker.patch("ostorlab.scanner.callbacks._connect_containers_registry")
+    mocker.patch("ostorlab.scanner.callbacks._update_state_reporter")
+    runtime_mock = mocker.MagicMock()
+    runtime_mock.can_run.return_value = True
+    select_runtime_mock = mocker.patch(
+        "ostorlab.scanner.callbacks.registry.select_runtime",
+        return_value=runtime_mock,
+    )
+    mocker.patch("ostorlab.scanner.callbacks._install_agents")
+
+    callbacks.start_scan(
+        reserved_scan,
+        mocker.MagicMock(),
+        gcp_logging_credential="gcp-credential",
+    )
+
+    select_runtime_mock.assert_called_once_with(
+        runtime_type="local",
+        scan_id="42",
+        run_default_agents=False,
+        gcp_logging_credential="gcp-credential",
+    )
+
+
 def testExtractAssets_whenAabAsset_shouldReturnCorrectAsset(
     mocker: plugin.MockerFixture,
 ) -> None:

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -85,16 +85,14 @@ def testStartScan_whenGcpCredentialProvided_forwardsItToLocalRuntime(
             "content": base64.b64encode(b"dummy_apk").decode(),
         },
     }
-    mocker.patch("ostorlab.scanner.callbacks._connect_containers_registry")
-    mocker.patch("ostorlab.scanner.callbacks._update_state_reporter")
+    mocker.patch("ostorlab.scanner.callbacks.docker.from_env")
+    mocker.patch("ostorlab.scanner.callbacks.install_agent.install")
     runtime_mock = mocker.MagicMock()
     runtime_mock.can_run.return_value = True
     select_runtime_mock = mocker.patch(
         "ostorlab.scanner.callbacks.registry.select_runtime",
         return_value=runtime_mock,
     )
-    mocker.patch("ostorlab.scanner.callbacks._install_agents")
-
     callbacks.start_scan(
         reserved_scan,
         mocker.MagicMock(),

--- a/tests/scanner/scan_handler_test.py
+++ b/tests/scanner/scan_handler_test.py
@@ -198,6 +198,35 @@ def testTriggerScanWithRollback_whenStartScanFails_rollsBack(
     assert call_arg.__class__.__name__ == "ScanUpdateStateAPIRequest"
 
 
+def testTriggerScanWithRollback_whenGcpCredentialProvided_forwardsItToStartScan(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Forward GCP logging credentials when starting a reserved scan."""
+    start_scan_mock = mocker.patch(
+        "ostorlab.scanner.scan_handler.callbacks.start_scan", return_value="42"
+    )
+    state_reporter = scanner_state_reporter.ScannerStateReporter(
+        scanner_id="GGBD-DJJD-DKJK-DJDD",
+        hostname="test-host",
+        ip="192.168.0.1",
+    )
+    scan_handler_instance = scan_handler.ScanHandler(
+        state_reporter=state_reporter,
+        gcp_logging_credential="gcp-credential",
+    )
+
+    result = scan_handler_instance._trigger_scan_with_rollback(
+        mocker.MagicMock(),
+        {"id": 42, "agentGroup": {"key": "test/group"}},
+        api_key="test-key",
+    )
+
+    assert result == "42"
+    assert (
+        start_scan_mock.call_args.kwargs["gcp_logging_credential"] == "gcp-credential"
+    )
+
+
 def testReserveSingleScan_whenEntryHasNoId_skipsEntry(
     mocker: plugin.MockerFixture,
 ) -> None:

--- a/tests/scanner/scan_handler_test.py
+++ b/tests/scanner/scan_handler_test.py
@@ -198,13 +198,33 @@ def testTriggerScanWithRollback_whenStartScanFails_rollsBack(
     assert call_arg.__class__.__name__ == "ScanUpdateStateAPIRequest"
 
 
-def testTriggerScanWithRollback_whenGcpCredentialProvided_forwardsItToStartScan(
+def testHandleMessages_whenGcpCredentialProvided_forwardsItToStartScan(
     mocker: plugin.MockerFixture,
 ) -> None:
     """Forward GCP logging credentials when starting a reserved scan."""
+    docker_client = mocker.patch(
+        "ostorlab.scanner.scan_handler.docker.from_env"
+    ).return_value
+    docker_client.services.list.return_value = [mocker.MagicMock()]
     start_scan_mock = mocker.patch(
         "ostorlab.scanner.scan_handler.callbacks.start_scan", return_value="42"
     )
+    mocker.patch(
+        "ostorlab.scanner.scan_handler.time.sleep",
+        side_effect=RuntimeError("stop"),
+    )
+    runner = mocker.MagicMock()
+    runner.execute.side_effect = [
+        {"data": {"scans": {"scans": [{"id": 42}]}}},
+        {
+            "data": {
+                "updateScan": {
+                    "success": True,
+                    "scan": {"id": 42, "agentGroup": {"key": "test/group"}},
+                }
+            }
+        },
+    ]
     state_reporter = scanner_state_reporter.ScannerStateReporter(
         scanner_id="GGBD-DJJD-DKJK-DJDD",
         hostname="test-host",
@@ -215,15 +235,14 @@ def testTriggerScanWithRollback_whenGcpCredentialProvided_forwardsItToStartScan(
         gcp_logging_credential="gcp-credential",
     )
 
-    result = scan_handler_instance._trigger_scan_with_rollback(
-        mocker.MagicMock(),
-        {"id": 42, "agentGroup": {"key": "test/group"}},
-        api_key="test-key",
-    )
+    with pytest.raises(RuntimeError, match="stop"):
+        scan_handler_instance.handle_messages(runner, api_key="test-key")
 
-    assert result == "42"
-    assert (
-        start_scan_mock.call_args.kwargs["gcp_logging_credential"] == "gcp-credential"
+    start_scan_mock.assert_called_once_with(
+        request={"id": 42, "agentGroup": {"key": "test/group"}},
+        state_reporter=state_reporter,
+        api_key="test-key",
+        gcp_logging_credential="gcp-credential",
     )
 
 


### PR DESCRIPTION
## Issue

Scans launched through `oxo scanner` were running successfully, but agent logs were not appearing in Google Cloud Logging.

## Cause

The scanner command loaded the GCP logging credential, but did not propagate it through the scanner worker and scan handler to `LocalRuntime`.

As a result, agent containers were created without the `GCP_LOGGING_CREDENTIAL` environment variable and could not initialize Google Cloud Logging.

## Fix

Propagate the existing GCP logging credential through:

`scanner CLI → scanner worker → ScanHandler → callbacks.start_scan → LocalRuntime → agent containers`

No changes were required to the existing local-runtime logging implementation.