### PR TITLE
fix: Pass api_key to fetch agent details since the ConfigManager api key value is lost when starting a new process.

### DIFF
--- a/src/ostorlab/cli/agent_fetcher.py
+++ b/src/ostorlab/cli/agent_fetcher.py
@@ -38,6 +38,7 @@ def get_details(
         agent_key: the agent key in the form : agent/org/name
         use_experimental: when True, the server includes experimental (prerelease)
             versions in the result set for this agent.
+        api_key: the API key for RE authentication
 
     Returns:
         dictionary of the agent information like : name, dockerLocation..

--- a/src/ostorlab/cli/agent_fetcher.py
+++ b/src/ostorlab/cli/agent_fetcher.py
@@ -29,7 +29,7 @@ class AgentDetailsNotFound(Error):
     """Agent not found error."""
 
 
-def get_details(agent_key: str, use_experimental: bool = False) -> dict[str, Any]:
+def get_details(agent_key: str, use_experimental: bool = False, api_key: str | None = None) -> dict[str, Any]:
     """Sends an API request with the agent key, and retrieve the agent information.
 
     Args:
@@ -47,6 +47,8 @@ def get_details(agent_key: str, use_experimental: bool = False) -> dict[str, Any
 
     if config_manager.is_authenticated is True:
         runner = authenticated_runner.AuthenticatedAPIRunner()
+    elif api_key is not None:
+        runner = authenticated_runner.AuthenticatedAPIRunner(api_key=api_key)
     else:
         runner = public_runner.PublicAPIRunner()
 

--- a/src/ostorlab/cli/agent_fetcher.py
+++ b/src/ostorlab/cli/agent_fetcher.py
@@ -29,7 +29,9 @@ class AgentDetailsNotFound(Error):
     """Agent not found error."""
 
 
-def get_details(agent_key: str, use_experimental: bool = False, api_key: str | None = None) -> dict[str, Any]:
+def get_details(
+    agent_key: str, use_experimental: bool = False, api_key: str | None = None
+) -> dict[str, Any]:
     """Sends an API request with the agent key, and retrieve the agent information.
 
     Args:

--- a/src/ostorlab/cli/install_agent.py
+++ b/src/ostorlab/cli/install_agent.py
@@ -161,7 +161,7 @@ def install(
         click Exit exception with status code 2 when the docker image does not exist.
     """
 
-    agent_details = agent_fetcher.get_details(agent_key)
+    agent_details = agent_fetcher.get_details(agent_key, api_key=api_key)
     agent_docker_location = agent_details["dockerLocation"]
     if agent_docker_location is None or not agent_details.get("versions", {}).get(
         "versions", []

--- a/src/ostorlab/cli/install_agent.py
+++ b/src/ostorlab/cli/install_agent.py
@@ -161,7 +161,7 @@ def install(
         click Exit exception with status code 2 when the docker image does not exist.
     """
 
-    agent_details = agent_fetcher.get_details(agent_key, api_key=api_key)
+    agent_details = agent_fetcher.get_details(agent_key=agent_key, api_key=api_key)
     agent_docker_location = agent_details["dockerLocation"]
     if agent_docker_location is None or not agent_details.get("versions", {}).get(
         "versions", []

--- a/tests/cli/test_agent_fetcher.py
+++ b/tests/cli/test_agent_fetcher.py
@@ -71,9 +71,7 @@ def testGetDetails_whenResponseHasNoErrors_returnsAgentDetails() -> None:
             assert result == {"key": "agent/ostorlab/nmap"}
 
 
-def testGetDetails_whenApiKeyProvided_buildsAuthenticatedRunnerWithApiKey() -> (
-    None
-):
+def testGetDetails_whenApiKeyProvided_buildsAuthenticatedRunnerWithApiKey() -> None:
     """Test that get_details builds the AuthenticatedAPIRunner with the provided api_key."""
     with mock.patch(
         "ostorlab.cli.agent_fetcher.configuration_manager.ConfigurationManager"
@@ -88,7 +86,9 @@ def testGetDetails_whenApiKeyProvided_buildsAuthenticatedRunnerWithApiKey() -> (
             with mock.patch(
                 "ostorlab.cli.agent_fetcher.agent_details_api.AgentDetailsAPIRequest"
             ) as mock_request_cls:
-                result = agent_fetcher.get_details("agent/ostorlab/nmap", api_key="test-api-key")
+                result = agent_fetcher.get_details(
+                    "agent/ostorlab/nmap", api_key="test-api-key"
+                )
 
                 mock_runner_cls.assert_called_once_with(api_key="test-api-key")
                 mock_request_cls.assert_called_once_with(

--- a/tests/cli/test_agent_fetcher.py
+++ b/tests/cli/test_agent_fetcher.py
@@ -71,6 +71,32 @@ def testGetDetails_whenResponseHasNoErrors_returnsAgentDetails() -> None:
             assert result == {"key": "agent/ostorlab/nmap"}
 
 
+def testGetDetails_whenApiKeyProvided_buildsAuthenticatedRunnerWithApiKey() -> (
+    None
+):
+    """Test that get_details builds the AuthenticatedAPIRunner with the provided api_key."""
+    with mock.patch(
+        "ostorlab.cli.agent_fetcher.configuration_manager.ConfigurationManager"
+    ) as mock_config_manager:
+        mock_config_manager.return_value.is_authenticated = False
+        with mock.patch(
+            "ostorlab.cli.agent_fetcher.authenticated_runner.AuthenticatedAPIRunner"
+        ) as mock_runner_cls:
+            mock_runner = mock.Mock()
+            mock_runner_cls.return_value = mock_runner
+            mock_runner.execute.return_value = {"data": {"agent": {"key": "value"}}}
+            with mock.patch(
+                "ostorlab.cli.agent_fetcher.agent_details_api.AgentDetailsAPIRequest"
+            ) as mock_request_cls:
+                result = agent_fetcher.get_details("agent/ostorlab/nmap", api_key="test-api-key")
+
+                mock_runner_cls.assert_called_once_with(api_key="test-api-key")
+                mock_request_cls.assert_called_once_with(
+                    "agent/ostorlab/nmap", use_experimental=False
+                )
+                assert result == {"key": "value"}
+
+
 def testGetContainerImage_whenExactVersionRequested_shouldReturnExactMatch() -> None:
     """Test that version matching is exact, not regex-based."""
     with mock.patch("ostorlab.cli.agent_fetcher.docker.from_env") as mock_docker:


### PR DESCRIPTION
 This PR adds support for authenticating API requests using an api_key in the get_details function of agent_fetcher.py. 

This is needed since we pass the APi_key as a parameter and should not rely on the singleton config manager. The config manager was initiated in the main process, and the forked process lost the values.
 
  Changes
   1. API Support (src/ostorlab/cli/agent_fetcher.py)
      - Added an optional api_key: str | None = None parameter to the get_details function.
      - Updated the authentication logic within get_details to check if api_key is provided when the
        manager is not authenticated. If an api_key is passed, it instantiates AuthenticatedAPIRunner
        with that key; otherwise, it falls back to the PublicAPIRunner.

   2. Unit Tests (tests/cli/test_agent_fetcher.py)
      - Added the unit test testGetDetails_whenApiKeyProvided_buildsAuthenticatedRunnerWithApiKey to
        verify that passing an api_key to get_details correctly instantiates AuthenticatedAPIRunner with
        the specified key and executes the details query successfully.
