### PR TITLE
fix: set up cloud logging in scanner workers

### DIFF
--- a/src/ostorlab/cli/scanner/scanner.py
+++ b/src/ostorlab/cli/scanner/scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import multiprocessing
 import os
@@ -56,6 +57,44 @@ def _configure_file_logging(
     if root_logger.level > log_level:
         root_logger.setLevel(log_level)
     logger.info("Persisting on-prem scanner logs to %s.", log_file_path)
+
+
+def _configure_gcp_logging(gcp_logging_credential: str | None, scanner_id: str) -> None:
+    """Attach a labeled Cloud Logging handler to the calling process.
+
+    The root CLI already sets up Cloud Logging, but its background transport thread does not survive the fork
+    performed to spawn the scan workers, so every worker must set up its own handler.
+    """
+    if gcp_logging_credential is None:
+        return
+
+    try:
+        import google.cloud.logging
+        from google.cloud.logging import handlers as gcp_handlers
+        from google.oauth2 import service_account
+    except ImportError:
+        logger.error(
+            "Could not import Google Cloud Logging, install it with `pip install 'ostorlab[google-cloud-logging]'"
+        )
+        return
+
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        if isinstance(handler, gcp_handlers.CloudLoggingHandler):
+            root_logger.removeHandler(handler)
+
+    credentials = service_account.Credentials.from_service_account_info(
+        json.loads(gcp_logging_credential)
+    )
+    client = google.cloud.logging.Client(credentials=credentials)
+    client.setup_logging(
+        labels={
+            "scanner_id": scanner_id,
+            "hostname": socket.gethostname(),
+            "pid": str(os.getpid()),
+        }
+    )
+    logger.info("Cloud Logging configured for scanner %s.", scanner_id)
 
 
 def _start_periodic_persist_state(
@@ -177,6 +216,7 @@ def start_scanner(
         gcp_logging_credential: GCP Logging JSON credentials for agent containers.
     """
     _configure_file_logging(log_file, log_level)
+    _configure_gcp_logging(gcp_logging_credential, scanner_id)
     if api_key is None:
         logger.error("No api key provided.")
 

--- a/src/ostorlab/cli/scanner/scanner.py
+++ b/src/ostorlab/cli/scanner/scanner.py
@@ -13,6 +13,19 @@ import time
 
 import click
 
+try:
+    from google.api_core import exceptions as google_api_exceptions
+    from google.auth import exceptions as google_auth_exceptions
+    from google.cloud import logging as gcp_logging
+    from google.cloud.logging import handlers as gcp_logging_handlers
+    from google.oauth2 import service_account
+except ImportError:
+    google_api_exceptions = None
+    google_auth_exceptions = None
+    gcp_logging = None
+    gcp_logging_handlers = None
+    service_account = None
+
 from ostorlab import configuration_manager as config_manager
 from ostorlab.cli import console as cli_console
 from ostorlab.cli.rootcli import rootcli
@@ -68,11 +81,13 @@ def _configure_gcp_logging(gcp_logging_credential: str | None, scanner_id: str) 
     if gcp_logging_credential is None:
         return
 
-    try:
-        import google.cloud.logging
-        from google.cloud.logging import handlers as gcp_handlers
-        from google.oauth2 import service_account
-    except ImportError:
+    if (
+        gcp_logging is None
+        or gcp_logging_handlers is None
+        or service_account is None
+        or google_api_exceptions is None
+        or google_auth_exceptions is None
+    ):
         logger.error(
             "Could not import Google Cloud Logging, install it with `pip install 'ostorlab[google-cloud-logging]'"
         )
@@ -80,20 +95,31 @@ def _configure_gcp_logging(gcp_logging_credential: str | None, scanner_id: str) 
 
     root_logger = logging.getLogger()
     for handler in list(root_logger.handlers):
-        if isinstance(handler, gcp_handlers.CloudLoggingHandler):
+        if isinstance(handler, gcp_logging_handlers.CloudLoggingHandler):
             root_logger.removeHandler(handler)
 
-    credentials = service_account.Credentials.from_service_account_info(
-        json.loads(gcp_logging_credential)
-    )
-    client = google.cloud.logging.Client(credentials=credentials)
-    client.setup_logging(
-        labels={
-            "scanner_id": scanner_id,
-            "hostname": socket.gethostname(),
-            "pid": str(os.getpid()),
-        }
-    )
+    try:
+        credentials = service_account.Credentials.from_service_account_info(
+            json.loads(gcp_logging_credential)
+        )
+        client = gcp_logging.Client(credentials=credentials)
+        client.setup_logging(
+            labels={
+                "scanner_id": scanner_id,
+                "hostname": socket.gethostname(),
+                "pid": str(os.getpid()),
+            }
+        )
+    except (
+        ValueError,
+        google_auth_exceptions.GoogleAuthError,
+        google_api_exceptions.GoogleAPIError,
+    ):
+        logger.exception(
+            "Could not configure Cloud Logging, scanner logs will only be persisted locally."
+        )
+        return
+
     logger.info("Cloud Logging configured for scanner %s.", scanner_id)
 
 

--- a/tests/cli/scanner/scanner_test.py
+++ b/tests/cli/scanner/scanner_test.py
@@ -6,6 +6,7 @@ import sys
 
 import pytest
 from click import testing as click_testing
+from google.cloud.logging import handlers as gcp_logging_handlers
 from pytest_mock import plugin
 
 from ostorlab.cli import rootcli
@@ -314,3 +315,45 @@ def testStartScanner_whenNoGcpCredential_doesNotSetUpCloudLogging(
     _start_scanner_sync(mocker, gcp_logging_credential=None)
 
     assert client_mock.call_count == 0
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def testStartScanner_whenInheritedCloudLoggingHandlerExists_removesItBeforeSetup(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """The handler inherited from the forked parent has a dead transport and must be dropped."""
+    mocker.patch("google.oauth2.service_account.Credentials.from_service_account_info")
+    mocker.patch("google.cloud.logging.Client")
+    inherited_handler = gcp_logging_handlers.CloudLoggingHandler(
+        mocker.Mock(), transport=mocker.Mock()
+    )
+    root_logger = logging.getLogger()
+    root_logger.addHandler(inherited_handler)
+
+    try:
+        _start_scanner_sync(
+            mocker, gcp_logging_credential='{"project_id": "test-project"}'
+        )
+    finally:
+        root_logger.removeHandler(inherited_handler)
+
+    assert inherited_handler not in root_logger.handlers
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def testStartScanner_whenGcpCredentialIsMalformed_doesNotCrashWorker(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """A bad credential must not kill the worker process before the scan loop starts."""
+    start_scan_loop_mock = mocker.patch(
+        "ostorlab.cli.scanner.scanner.scan_handler.start_scan_loop"
+    )
+
+    scanner_cli.start_scanner(
+        api_key=None,
+        scanner_id="11226DS",
+        state_reporter=mocker.Mock(),
+        gcp_logging_credential="not-json",
+    )
+
+    assert start_scan_loop_mock.call_count == 1

--- a/tests/cli/scanner/scanner_test.py
+++ b/tests/cli/scanner/scanner_test.py
@@ -1,6 +1,7 @@
 """Unit tests for the ostorlab scanner subcommand."""
 
 import logging
+import os
 import sys
 
 import pytest
@@ -284,3 +285,32 @@ def testScannerCommandInvocation_whenLogLevelIsProvided_passesLogLevelToWorker(
     )
     assert scanner_log_file == str(log_file)
     assert scanner_log_level == logging.DEBUG
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def testStartScanner_whenGcpCredentialProvided_setsUpLabeledCloudLoggingInWorker(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """The worker process must set up its own Cloud Logging handler since the parent's does not survive the fork."""
+    mocker.patch("google.oauth2.service_account.Credentials.from_service_account_info")
+    client_mock = mocker.patch("google.cloud.logging.Client")
+
+    _start_scanner_sync(mocker, gcp_logging_credential='{"project_id": "test-project"}')
+
+    setup_logging_mock = client_mock.return_value.setup_logging
+    assert setup_logging_mock.call_count == 1
+    labels = setup_logging_mock.call_args.kwargs["labels"]
+    assert labels["scanner_id"] == "11226DS"
+    assert labels["pid"] == str(os.getpid())
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def testStartScanner_whenNoGcpCredential_doesNotSetUpCloudLogging(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """No Cloud Logging setup should happen when no credential is passed down to the worker."""
+    client_mock = mocker.patch("google.cloud.logging.Client")
+
+    _start_scanner_sync(mocker, gcp_logging_credential=None)
+
+    assert client_mock.call_count == 0


### PR DESCRIPTION
Scanner worker processes were not shipping logs to Cloud Logging.

`rootcli` calls `client.setup_logging()` in the parent process, then `scanner` forks
workers with `multiprocessing.Process`. The Cloud Logging background transport thread
does not survive the fork, so records emitted by the workers were queued and never sent.
In practice only the single pre-fork line reached Cloud Logging per restart, and all
scan-handling logs existed solely in `~/.ostorlab/scanner.log`.

Each worker now sets up its own Cloud Logging handler, dropping the inherited dead one
first, and labels entries with `scanner_id`, `hostname` and `pid`.

```mermaid
flowchart LR
    A[rootcli: setup_logging] --> B[fork worker]
    B -- before --> C[dead transport, logs dropped]
    B -- after --> D[worker: own setup_logging + labels] --> E[Cloud Logging]
```
