### PR TITLE
fix: keep caller logging when running migrations

### DIFF
--- a/src/ostorlab/runtimes/local/models/alembic/env.py
+++ b/src/ostorlab/runtimes/local/models/alembic/env.py
@@ -17,7 +17,12 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-if config.config_file_name is not None:
+# `fileConfig` replaces the root logger handlers, so callers running migrations embedded in a long-lived process
+# opt out with the `configure_logger` attribute to keep their own logging setup.
+if (
+    config.config_file_name is not None
+    and config.attributes.get("configure_logger", True) is True
+):
     fileConfig(config.config_file_name)
 
 # add your model's MetaData object here

--- a/src/ostorlab/runtimes/local/models/models.py
+++ b/src/ostorlab/runtimes/local/models/models.py
@@ -97,6 +97,7 @@ class Database:
             pathlib.Path(__file__).parent.absolute() / "alembic.ini"
         )
         self._alembic_cfg = config.Config(str(self._alembic_ini_path))
+        self._alembic_cfg.attributes["configure_logger"] = False
 
     def __enter__(self) -> orm.Session:
         """Context manager enter method, responsible for migrating the local database and returning a session object."""

--- a/tests/runtimes/local/models/models_test.py
+++ b/tests/runtimes/local/models/models_test.py
@@ -1,5 +1,7 @@
 """Tests for Models class."""
 
+import logging
+
 from pytest_mock import plugin
 
 from ostorlab.assets import android_aab, android_apk, ios_ipa, ipv4, link
@@ -853,3 +855,21 @@ def testAssetModels_whenCreateFromAssetsDefinitionWithMultiAsset_nestedAssetsCre
         assert len(links) == 1
         assert links[0].url == "https://example.com/test"
         assert links[0].method == "GET"
+
+
+def testDatabaseMigration_always_keepsCallerLoggingHandlers(mocker, db_engine_path):
+    """Running migrations embedded must not let alembic's fileConfig replace the caller's root handlers."""
+    mocker.patch.object(models, "ENGINE_URL", db_engine_path)
+    caller_handler = logging.NullHandler()
+    root_logger = logging.getLogger()
+    root_logger.addHandler(caller_handler)
+    root_level = root_logger.level
+
+    try:
+        with models.Database() as session:
+            assert session.query(models.Scan).count() == 0
+
+        assert caller_handler in root_logger.handlers
+        assert root_logger.level == root_level
+    finally:
+        root_logger.removeHandler(caller_handler)


### PR DESCRIPTION
Running migrations embedded reconfigured the host process logging.

`Database` runs alembic in-process, and `env.py` calls `fileConfig(alembic.ini)`, which
replaces the root logger handlers and drops the root level to `WARN`. Every log record
emitted after the first `Database` use was lost — on the on-prem scanner that means the
whole tail of scan startup (network creation, agent health checks, asset injection, and
any `AgentNotHealthy` / `UnhealthyService` error) never reached Cloud Logging or
`scanner.log`, only container stdout.

`env.py` now honors a `configure_logger` config attribute, and `Database` opts out.
The alembic CLI is unaffected.

```mermaid
flowchart LR
    A[Database migrate] --> B[env.py fileConfig]
    B -- before --> C[root handlers replaced, level WARN]
    C --> D[scan startup logs lost]
    B -- after --> E{configure_logger?}
    E -- CLI: true --> B2[fileConfig]
    E -- embedded: false --> F[caller logging untouched]
```
