### PR TITLE
fix: log scan lifecycle console messages

### DIFF
--- a/src/ostorlab/cli/agent_fetcher.py
+++ b/src/ostorlab/cli/agent_fetcher.py
@@ -14,11 +14,9 @@ from ostorlab.agent import definitions as agent_definitions
 from ostorlab.apis import agent_details as agent_details_api
 from ostorlab.apis.runners import authenticated_runner, public_runner
 from ostorlab.apis.runners import runner as base_runner
-from ostorlab.cli import console as cli_console
 from ostorlab.utils import version as version_definition
 
 logger = logging.getLogger(__name__)
-console = cli_console.Console(logger=logger)
 
 
 class Error(Exception):

--- a/src/ostorlab/cli/agent_fetcher.py
+++ b/src/ostorlab/cli/agent_fetcher.py
@@ -17,8 +17,8 @@ from ostorlab.apis.runners import runner as base_runner
 from ostorlab.cli import console as cli_console
 from ostorlab.utils import version as version_definition
 
-console = cli_console.Console()
 logger = logging.getLogger(__name__)
+console = cli_console.Console(logger=logger)
 
 
 class Error(Exception):

--- a/src/ostorlab/cli/console.py
+++ b/src/ostorlab/cli/console.py
@@ -40,6 +40,8 @@ class Console:
             text: The success text to show.
         """
         self._console.print(f":heavy_check_mark: {text}", style="success")
+        if self._logger is not None:
+            self._logger.info(text)
 
     def error(self, text: str) -> None:
         """Shows error message.

--- a/src/ostorlab/runtimes/local/models/models.py
+++ b/src/ostorlab/runtimes/local/models/models.py
@@ -46,7 +46,7 @@ ENGINE_URL = f"sqlite:///{config_manager.ConfigurationManager().conf_path}/db.sq
 OSTORLAB_BASE_MIGRATION_ID = "35cd577ef0e5"
 
 logger = logging.getLogger(__name__)
-console = cli_console.Console()
+console = cli_console.Console(logger=logger)
 MIGRATION_LOCK = threading.Lock()
 
 convention = {

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -38,7 +38,7 @@ from ostorlab.utils import risk_rating, styles, volumes
 NETWORK_PREFIX = "ostorlab_local_network"
 
 logger = logging.getLogger(__name__)
-console = cli_console.Console()
+console = cli_console.Console(logger=logger)
 
 ASSET_CLOUD_INJECTION_AGENT = "agent/ostorlab/cloud_inject_asset"
 ASSET_INJECTION_AGENT_DEFAULT = "agent/ostorlab/inject_asset"

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -1,5 +1,6 @@
 """Unittest for local runtime."""
 
+import logging
 from typing import Any
 
 import docker
@@ -662,3 +663,11 @@ def testLocalRuntimeInjectAssets_whenAgentSettingsNone_usesDefaultSettings(
     mock_start_agent.assert_called_once()
     _args, kwargs = mock_start_agent.call_args
     assert kwargs["agent"].key == "agent/ostorlab/inject_asset"
+
+
+def testLocalRuntimeConsole_whenMessageIsPrinted_emitsLogRecord(caplog) -> None:
+    """Scan lifecycle messages must reach the logging handlers, not only stdout."""
+    with caplog.at_level(logging.INFO):
+        local_runtime.console.info("Creating network")
+
+    assert "Creating network" in caplog.text

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -671,3 +671,11 @@ def testLocalRuntimeConsole_whenMessageIsPrinted_emitsLogRecord(caplog) -> None:
         local_runtime.console.info("Creating network")
 
     assert "Creating network" in caplog.text
+
+
+def testLocalRuntimeConsole_whenSuccessIsPrinted_emitsLogRecord(caplog) -> None:
+    """Terminal lifecycle messages are reported as success and must reach the logging handlers too."""
+    with caplog.at_level(logging.INFO):
+        local_runtime.console.success("Scan created successfully")
+
+    assert "Scan created successfully" in caplog.text


### PR DESCRIPTION
Scan lifecycle messages were printed to stdout only, never logged.

`Console` takes an optional logger and only emits log records when one is passed.
The local runtime, the local models module and the agent fetcher all built a
`Console()` without one, so `Creating network`, `Starting services`,
`Checking agents are healthy`, `Injecting assets` and `Scan created successfully`
existed solely in container stdout — absent from the log file and from Cloud Logging.
`lite_local` already passes a logger; this aligns the others.

Stacked on #1166: without that fix, alembic's `fileConfig` disables the module loggers
during the first migration and these records are dropped anyway.

```mermaid
flowchart LR
    A[console.info] --> B[rich print to stdout]
    A --> C{logger set?}
    C -- before: no --> D[record dropped]
    C -- after: yes --> E[log file + Cloud Logging]
```
