### PR TITLE
fix: ship worker logs over http transport

### DIFF
--- a/src/ostorlab/cli/scanner/scanner.py
+++ b/src/ostorlab/cli/scanner/scanner.py
@@ -102,7 +102,9 @@ def _configure_gcp_logging(gcp_logging_credential: str | None, scanner_id: str) 
         credentials = service_account.Credentials.from_service_account_info(
             json.loads(gcp_logging_credential)
         )
-        client = gcp_logging.Client(credentials=credentials)
+        # The gRPC channel opened by the parent process does not survive the fork, and reusing it silently
+        # drops every record, so workers ship over HTTP instead.
+        client = gcp_logging.Client(credentials=credentials, _use_grpc=False)
         client.setup_logging(
             labels={
                 "scanner_id": scanner_id,

--- a/tests/cli/scanner/scanner_test.py
+++ b/tests/cli/scanner/scanner_test.py
@@ -303,6 +303,7 @@ def testStartScanner_whenGcpCredentialProvided_setsUpLabeledCloudLoggingInWorker
     labels = setup_logging_mock.call_args.kwargs["labels"]
     assert labels["scanner_id"] == "11226DS"
     assert labels["pid"] == str(os.getpid())
+    assert client_mock.call_args.kwargs["_use_grpc"] is False
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")


### PR DESCRIPTION
Worker log records were still being dropped after the per-worker handler was added.

The parent process sets up Cloud Logging before forking the scan workers. Each worker now
builds its own client, but the default gRPC transport reuses the channel inherited from the
parent, which does not survive `fork` — the records are queued and never sent, silently.
The symptom is a worker that reports `Cloud Logging configured` and then logs nothing to
Cloud Logging for the rest of its life.

Workers now build the client with `_use_grpc=False` so they open their own HTTP connection.

Verified end to end against a local scan: before the change no worker record arrived while
the pre-fork parent record did; after it, the full scan lifecycle arrives labeled with the
worker `pid`.

```mermaid
flowchart LR
    A[parent: setup_logging, gRPC channel] --> B[fork worker]
    B --> C[worker: new client]
    C -- gRPC, inherited channel --> D[records queued, dropped]
    C -- _use_grpc=False --> E[Cloud Logging]
```
