### PR TITLE
fix: log scan lifecycle and ship worker logs

### DIFF
--- a/src/ostorlab/cli/agent_fetcher.py
+++ b/src/ostorlab/cli/agent_fetcher.py
@@ -14,11 +14,9 @@ from ostorlab.agent import definitions as agent_definitions
 from ostorlab.apis import agent_details as agent_details_api
 from ostorlab.apis.runners import authenticated_runner, public_runner
 from ostorlab.apis.runners import runner as base_runner
-from ostorlab.cli import console as cli_console
 from ostorlab.utils import version as version_definition
 
 logger = logging.getLogger(__name__)
-console = cli_console.Console(logger=logger)
 
 
 class Error(Exception):

--- a/src/ostorlab/cli/agent_fetcher.py
+++ b/src/ostorlab/cli/agent_fetcher.py
@@ -17,8 +17,8 @@ from ostorlab.apis.runners import runner as base_runner
 from ostorlab.cli import console as cli_console
 from ostorlab.utils import version as version_definition
 
-console = cli_console.Console()
 logger = logging.getLogger(__name__)
+console = cli_console.Console(logger=logger)
 
 
 class Error(Exception):

--- a/src/ostorlab/cli/console.py
+++ b/src/ostorlab/cli/console.py
@@ -40,6 +40,8 @@ class Console:
             text: The success text to show.
         """
         self._console.print(f":heavy_check_mark: {text}", style="success")
+        if self._logger is not None:
+            self._logger.info(text)
 
     def error(self, text: str) -> None:
         """Shows error message.

--- a/src/ostorlab/cli/scanner/scanner.py
+++ b/src/ostorlab/cli/scanner/scanner.py
@@ -102,7 +102,9 @@ def _configure_gcp_logging(gcp_logging_credential: str | None, scanner_id: str) 
         credentials = service_account.Credentials.from_service_account_info(
             json.loads(gcp_logging_credential)
         )
-        client = gcp_logging.Client(credentials=credentials)
+        # The gRPC channel opened by the parent process does not survive the fork, and reusing it silently
+        # drops every record, so workers ship over HTTP instead.
+        client = gcp_logging.Client(credentials=credentials, _use_grpc=False)
         client.setup_logging(
             labels={
                 "scanner_id": scanner_id,

--- a/src/ostorlab/runtimes/local/models/models.py
+++ b/src/ostorlab/runtimes/local/models/models.py
@@ -46,7 +46,7 @@ ENGINE_URL = f"sqlite:///{config_manager.ConfigurationManager().conf_path}/db.sq
 OSTORLAB_BASE_MIGRATION_ID = "35cd577ef0e5"
 
 logger = logging.getLogger(__name__)
-console = cli_console.Console()
+console = cli_console.Console(logger=logger)
 MIGRATION_LOCK = threading.Lock()
 
 convention = {

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -38,7 +38,7 @@ from ostorlab.utils import risk_rating, styles, volumes
 NETWORK_PREFIX = "ostorlab_local_network"
 
 logger = logging.getLogger(__name__)
-console = cli_console.Console()
+console = cli_console.Console(logger=logger)
 
 ASSET_CLOUD_INJECTION_AGENT = "agent/ostorlab/cloud_inject_asset"
 ASSET_INJECTION_AGENT_DEFAULT = "agent/ostorlab/inject_asset"

--- a/tests/cli/scanner/scanner_test.py
+++ b/tests/cli/scanner/scanner_test.py
@@ -303,6 +303,7 @@ def testStartScanner_whenGcpCredentialProvided_setsUpLabeledCloudLoggingInWorker
     labels = setup_logging_mock.call_args.kwargs["labels"]
     assert labels["scanner_id"] == "11226DS"
     assert labels["pid"] == str(os.getpid())
+    assert client_mock.call_args.kwargs["_use_grpc"] is False
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")

--- a/tests/cli/scanner/scanner_test.py
+++ b/tests/cli/scanner/scanner_test.py
@@ -1,11 +1,13 @@
 """Unit tests for the ostorlab scanner subcommand."""
 
+import inspect
 import logging
 import os
 import sys
 
 import pytest
 from click import testing as click_testing
+from google.cloud import logging as gcp_logging
 from google.cloud.logging import handlers as gcp_logging_handlers
 from pytest_mock import plugin
 
@@ -358,3 +360,15 @@ def testStartScanner_whenGcpCredentialIsMalformed_doesNotCrashWorker(
     )
 
     assert start_scan_loop_mock.call_count == 1
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def testCloudLoggingClient_always_acceptsDisablingGrpcTransport() -> None:
+    """Workers disable the fork-unsafe gRPC transport through a private parameter of the client.
+
+    The client is mocked in the tests above, so a mock would happily accept a parameter the library no longer
+    supports. Assert against the real signature instead, to fail on upgrade rather than silently dropping logs.
+    """
+    parameters = inspect.signature(gcp_logging.Client.__init__).parameters
+
+    assert "_use_grpc" in parameters

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -665,27 +665,34 @@ def testLocalRuntimeInjectAssets_whenAgentSettingsNone_usesDefaultSettings(
     assert kwargs["agent"].key == "agent/ostorlab/inject_asset"
 
 
-def _enable_runtime_logger() -> None:
-    """Re-enable the runtime logger.
+@pytest.fixture
+def runtime_logger() -> Any:
+    """Yield the runtime logger enabled, and restore its state afterwards.
 
-    Running migrations in-process lets alembic's `fileConfig` disable the already existing loggers, so any earlier
-    test touching the local database leaves this one disabled.
+    Running migrations in-process lets alembic's `fileConfig` disable the already existing loggers, so the state of
+    this logger depends on whether an earlier test touched the local database.
     """
-    logging.getLogger(local_runtime.__name__).disabled = False
+    logger = logging.getLogger(local_runtime.__name__)
+    was_disabled = logger.disabled
+    logger.disabled = False
+    yield logger
+    logger.disabled = was_disabled
 
 
-def testLocalRuntimeConsole_whenMessageIsPrinted_emitsLogRecord(caplog) -> None:
+def testLocalRuntimeConsole_whenMessageIsPrinted_emitsLogRecord(
+    caplog, runtime_logger
+) -> None:
     """Scan lifecycle messages must reach the logging handlers, not only stdout."""
-    _enable_runtime_logger()
     with caplog.at_level(logging.INFO):
         local_runtime.console.info("Creating network")
 
     assert "Creating network" in caplog.text
 
 
-def testLocalRuntimeConsole_whenSuccessIsPrinted_emitsLogRecord(caplog) -> None:
+def testLocalRuntimeConsole_whenSuccessIsPrinted_emitsLogRecord(
+    caplog, runtime_logger
+) -> None:
     """Terminal lifecycle messages are reported as success and must reach the logging handlers too."""
-    _enable_runtime_logger()
     with caplog.at_level(logging.INFO):
         local_runtime.console.success("Scan created successfully")
 

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -1,5 +1,6 @@
 """Unittest for local runtime."""
 
+import logging
 from typing import Any
 
 import docker
@@ -662,3 +663,11 @@ def testLocalRuntimeInjectAssets_whenAgentSettingsNone_usesDefaultSettings(
     mock_start_agent.assert_called_once()
     _args, kwargs = mock_start_agent.call_args
     assert kwargs["agent"].key == "agent/ostorlab/inject_asset"
+
+
+def testLocalRuntimeConsole_whenMessageIsPrinted_emitsLogRecord(caplog) -> None:
+    """Scan lifecycle messages must reach the logging handlers, not only stdout."""
+    with caplog.at_level(logging.INFO):
+        local_runtime.console.info("Creating network")
+
+    assert "Creating network" in caplog.text

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -665,8 +665,18 @@ def testLocalRuntimeInjectAssets_whenAgentSettingsNone_usesDefaultSettings(
     assert kwargs["agent"].key == "agent/ostorlab/inject_asset"
 
 
+def _enable_runtime_logger() -> None:
+    """Re-enable the runtime logger.
+
+    Running migrations in-process lets alembic's `fileConfig` disable the already existing loggers, so any earlier
+    test touching the local database leaves this one disabled.
+    """
+    logging.getLogger(local_runtime.__name__).disabled = False
+
+
 def testLocalRuntimeConsole_whenMessageIsPrinted_emitsLogRecord(caplog) -> None:
     """Scan lifecycle messages must reach the logging handlers, not only stdout."""
+    _enable_runtime_logger()
     with caplog.at_level(logging.INFO):
         local_runtime.console.info("Creating network")
 
@@ -675,6 +685,7 @@ def testLocalRuntimeConsole_whenMessageIsPrinted_emitsLogRecord(caplog) -> None:
 
 def testLocalRuntimeConsole_whenSuccessIsPrinted_emitsLogRecord(caplog) -> None:
     """Terminal lifecycle messages are reported as success and must reach the logging handlers too."""
+    _enable_runtime_logger()
     with caplog.at_level(logging.INFO):
         local_runtime.console.success("Scan created successfully")
 

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -671,3 +671,11 @@ def testLocalRuntimeConsole_whenMessageIsPrinted_emitsLogRecord(caplog) -> None:
         local_runtime.console.info("Creating network")
 
     assert "Creating network" in caplog.text
+
+
+def testLocalRuntimeConsole_whenSuccessIsPrinted_emitsLogRecord(caplog) -> None:
+    """Terminal lifecycle messages are reported as success and must reach the logging handlers too."""
+    with caplog.at_level(logging.INFO):
+        local_runtime.console.success("Scan created successfully")
+
+    assert "Scan created successfully" in caplog.text


### PR DESCRIPTION
Scan lifecycle messages never reached the log file or Cloud Logging, and worker log records were silently dropped. Two independent causes.

**Console without a logger.** `Console` only emits log records when it is built with one. The local runtime, the local models module and the agent fetcher built theirs without, so `Creating network`, `Starting services`, `Checking agents are healthy`, `Injecting assets` and `Scan created successfully` existed only on stdout. `Console.success()` never logged at all. `lite_local` already passed a logger; this aligns the rest.

**gRPC transport after fork.** Scan workers are forked after the parent sets up Cloud Logging. Each worker builds its own client, but the default gRPC transport reuses the channel inherited from the parent, which does not survive `fork`, so records are queued and never sent. Workers now use `_use_grpc=False`.

Verified against a live scan: production has zero occurrences of the lifecycle messages over 12h of scans, while a patched scanner emits the full sequence to Cloud Logging labeled with the worker `pid`.

```mermaid
flowchart LR
    A["console.info / console.success"] --> B["stdout"]
    A --> C{"logger set?"}
    C -- "no" --> D["record dropped"]
    C -- "yes" --> E["log file"]
    E --> F{"worker transport"}
    F -- "gRPC after fork" --> G["queued, never sent"]
    F -- "http" --> H["Cloud Logging"]
```
