### PR TITLE
fix: Fix prepare_network asset to align with API return type.

### DIFF
--- a/src/ostorlab/scanner/callbacks.py
+++ b/src/ostorlab/scanner/callbacks.py
@@ -81,6 +81,23 @@ def _prepare_ip_asset(ip_asset_value: dict[str, Any]) -> asset.Asset:
         raise ValueError(f"Invalid Ip address {host}")
 
 
+def _prepare_network_asset(netwrok_asset_value: str) -> asset.Asset:
+    """Return IP assets from network_asset_value str."""
+    ip_network = ipaddress.ip_network(netwrok_asset_value, strict=False)
+    if ip_network.version == 4:
+        return ipv4.IPv4(
+            host=ip_network.network_address.exploded,
+            mask=str(ip_network.prefixlen),
+        )
+    elif ip_network.version == 6:
+        return ipv6.IPv6(
+            host=ip_network.network_address.exploded,
+            mask=str(ip_network.prefixlen),
+        )
+    else:
+        raise ValueError(f"Invalid Network address {netwrok_asset_value}")
+
+
 def _build_risk_kwargs(target_dict: dict[str, Any] | None) -> dict[str, Any]:
     """Builds risk kwargs for the first resolved target asset."""
     if target_dict is None:
@@ -158,7 +175,7 @@ def _extract_assets(asset_data: dict[str, Any]) -> list[asset.Asset]:
         return [_prepare_ip_asset(ip_asset_value=kwargs)]
     elif typename == "NetworkAssetType":
         return [
-            _prepare_ip_asset(ip_asset_value=ip) for ip in kwargs.get("networks") or []
+            _prepare_network_asset(netwrok_asset_value=network) for network in kwargs.get("networks") or []
         ]
     elif typename == "UrlAssetType":
         return [

--- a/src/ostorlab/scanner/callbacks.py
+++ b/src/ostorlab/scanner/callbacks.py
@@ -175,7 +175,8 @@ def _extract_assets(asset_data: dict[str, Any]) -> list[asset.Asset]:
         return [_prepare_ip_asset(ip_asset_value=kwargs)]
     elif typename == "NetworkAssetType":
         return [
-            _prepare_network_asset(netwrok_asset_value=network) for network in kwargs.get("networks") or []
+            _prepare_network_asset(netwrok_asset_value=network)
+            for network in kwargs.get("networks") or []
         ]
     elif typename == "UrlAssetType":
         return [

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -713,9 +713,7 @@ def testExtractAssets_whenNetworkAsset_shouldReturnCorrectAsset(
         },
         "asset": {
             "__typename": "NetworkAssetType",
-            "networks": [
-               "18.2.46.129/32", "13.8.98.58/32"
-            ],
+            "networks": ["18.2.46.129/32", "13.8.98.58/32"],
         },
     }
     runtime_mock = _setup_start_scan_mocks(mocker)

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -714,10 +714,7 @@ def testExtractAssets_whenNetworkAsset_shouldReturnCorrectAsset(
         "asset": {
             "__typename": "NetworkAssetType",
             "networks": [
-                {"host": "8.8.8.8"},
-                {"host": "127.0.0.1"},
-                {"host": "2001:db8::"},
-                {"host": "192.168.1.1", "mask": "24"},
+               "18.2.46.129/32", "13.8.98.58/32"
             ],
         },
     }

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -723,24 +723,14 @@ def testExtractAssets_whenNetworkAsset_shouldReturnCorrectAsset(
 
     ip_asset1 = runtime_mock.scan.call_args[1].get("assets")[0]
     assert isinstance(ip_asset1, ipv4.IPv4) is True
-    assert ip_asset1.host == "8.8.8.8"
+    assert ip_asset1.host == "18.2.46.129"
     assert ip_asset1.version == 4
     assert ip_asset1.mask == "32"
     ip_asset2 = runtime_mock.scan.call_args[1].get("assets")[1]
     assert isinstance(ip_asset2, ipv4.IPv4) is True
-    assert ip_asset2.host == "127.0.0.1"
+    assert ip_asset2.host == "13.8.98.58"
     assert ip_asset2.version == 4
     assert ip_asset2.mask == "32"
-    ip_asset3 = runtime_mock.scan.call_args[1].get("assets")[2]
-    assert isinstance(ip_asset3, ipv6.IPv6) is True
-    assert ip_asset3.host == "2001:0db8:0000:0000:0000:0000:0000:0000"
-    assert ip_asset3.version == 6
-    assert ip_asset3.mask == "128"
-    ip_asset4 = runtime_mock.scan.call_args[1].get("assets")[3]
-    assert isinstance(ip_asset4, ipv4.IPv4) is True
-    assert ip_asset4.host == "192.168.1.1"
-    assert ip_asset4.version == 4
-    assert ip_asset4.mask == "24"
 
 
 def testStartScan_whenApiKeyProvided_forwardsApiKeyToInstallAgent(


### PR DESCRIPTION
For the Newtrok asset, the API returns a list of strings while the prepare_newtork_asset function processes a dict.

This PR aligns the processing with the API value.
