### PR TITLE
fix: alias the multi asset url members to keep the updateScan query valid

### DIFF
--- a/src/ostorlab/apis/scan_update_state.py
+++ b/src/ostorlab/apis/scan_update_state.py
@@ -82,7 +82,7 @@ class ScanUpdateStateAPIRequest(request.APIRequest):
                       harmonyosRpk { __typename path contentUrl }
                       repositories { __typename provider repositoryUrl commitHash }
                       repositoryArchives { __typename path contentUrl }
-                      urls { __typename urls }
+                      urlAssets: urls { __typename urls }
                       ips { __typename host version mask }
                       ipv4s { __typename host version mask }
                       ipv6s { __typename host version mask }

--- a/src/ostorlab/scanner/callbacks.py
+++ b/src/ostorlab/scanner/callbacks.py
@@ -63,7 +63,10 @@ _MULTI_ASSET_MEMBER_KEYS = (
     "harmonyosRpk",
     "repositories",
     "repositoryArchives",
-    "urls",
+    # The url members are aliased in the query: a plain `urls` would share its response
+    # name with `UrlAssetType.urls`, which returns strings rather than url assets, and
+    # the two shapes cannot merge into one selection set.
+    "urlAssets",
     "ips",
     "ipv4s",
     "ipv6s",

--- a/tests/apis/scan_update_state_test.py
+++ b/tests/apis/scan_update_state_test.py
@@ -73,7 +73,7 @@ def testScanUpdateStateAPIRequest_whenFullDetails_queryContainsMultiAssetMembers
         in api_request.query
     )
     assert "repositoryArchives { __typename path contentUrl }" in api_request.query
-    assert "urls { __typename urls }" in api_request.query
+    assert "urlAssets: urls { __typename urls }" in api_request.query
     assert "ips { __typename host version mask }" in api_request.query
     assert "ipv4s { __typename host version mask }" in api_request.query
     assert "ipv6s { __typename host version mask }" in api_request.query
@@ -130,3 +130,48 @@ def testScanUpdateStateAPIRequest_whenFullDetails_dataContainsSameVariables() ->
     assert variables["scanId"] == 7
     assert variables["progress"] == "locked"
     assert variables["scannerId"] is None
+
+
+def testScanUpdateStateAPIRequest_whenFullDetails_multiAssetSelectsNoConflictingName() -> (
+    None
+):
+    """Test no multi asset member shares a response name with a sibling asset fragment.
+
+    Fields sharing a response name in one selection set must have the same response
+    shape, even on types that cannot both be the concrete one. A member selecting an
+    asset under a name a sibling fragment selects a scalar under makes the whole query
+    invalid, so every scan reservation fails, not only the multi asset ones. Aliasing
+    the member is what keeps the two apart.
+    """
+    api_request = scan_update_state.ScanUpdateStateAPIRequest(
+        scan_id=1, progress="locked", full_details=True
+    )
+    lines = api_request.query.split("\n")
+    multi_asset_start = next(
+        index
+        for index, line in enumerate(lines)
+        if "... on MultiAssetsAssetType" in line
+    )
+    multi_asset_end = next(
+        index
+        for index in range(multi_asset_start + 1, len(lines))
+        if lines[index].strip() == "}"
+    )
+
+    response_names = {
+        line.strip().split(" ")[0].split("{")[0].rstrip(":")
+        for line in lines[multi_asset_start + 1 : multi_asset_end]
+        if line.strip() != ""
+    }
+    sibling_names = set()
+    for line in lines[:multi_asset_start]:
+        stripped = line.strip()
+        if stripped.startswith("... on ") is True and stripped.endswith("}") is True:
+            selection = stripped[stripped.index("{") + 1 : stripped.rindex("}")]
+            sibling_names.update(
+                token
+                for token in selection.split()
+                if token not in ("{", "}") and token.endswith(":") is False
+            )
+
+    assert response_names & sibling_names == set()

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -978,7 +978,7 @@ def testExtractAssets_whenMultiAsset_shouldReturnOneMultiAsset(
                     "contentUrl": "https://storage.co/archive.zip",
                 }
             ],
-            "urls": [
+            "urlAssets": [
                 {
                     "__typename": "UrlAssetType",
                     "urls": ["https://ostorlab.co", "https://google.com"],
@@ -1065,7 +1065,9 @@ def testExtractAssets_whenMultiAssetWithStoreMember_shouldReturnStoreAsMobileMem
                 "__typename": "AndroidPackageNameAssetType",
                 "packageName": "com.ostorlab.app",
             },
-            "urls": [{"__typename": "UrlAssetType", "urls": ["https://ostorlab.co"]}],
+            "urlAssets": [
+                {"__typename": "UrlAssetType", "urls": ["https://ostorlab.co"]}
+            ],
         },
     }
     runtime_mock = _setup_start_scan_mocks(mocker)
@@ -1118,7 +1120,9 @@ def testExtractAssets_whenMultiAssetApiSchemaHasNoEndpointUrl_shouldSkipIt(
         },
         "asset": {
             "__typename": "MultiAssetsAssetType",
-            "urls": [{"__typename": "UrlAssetType", "urls": ["https://ostorlab.co"]}],
+            "urlAssets": [
+                {"__typename": "UrlAssetType", "urls": ["https://ostorlab.co"]}
+            ],
             "apiSchemas": [
                 {"endpointUrl": None, "contentUrl": "https://storage.co/openapi.json"},
                 {"endpointUrl": "   ", "contentUrl": "https://storage.co/blank.json"},
@@ -1147,7 +1151,9 @@ def testExtractAssets_whenMultiAssetMemberIsUnknownType_shouldLeaveItOutAndLog(
         },
         "asset": {
             "__typename": "MultiAssetsAssetType",
-            "urls": [{"__typename": "UrlAssetType", "urls": ["https://ostorlab.co"]}],
+            "urlAssets": [
+                {"__typename": "UrlAssetType", "urls": ["https://ostorlab.co"]}
+            ],
             "files": [{"__typename": "UnknownAssetType", "path": "/tmp/mystery"}],
         },
     }


### PR DESCRIPTION
Since #1177 shipped, every scan reservation fails. `updateScan` returns a 400 for every scan, multi asset or not, and the scanner reserves nothing:

```
Exception reserving scan 420992: Response status code is 400:
Fields 'urls' conflict because they return conflicting types '[String!]!' and '[UrlAssetType!]!'.
Use different aliases on the fields to fetch both if this was intentional.
```

The multi asset members are selected alongside the other asset fragments, in one selection set. `MultiAssetsAssetType.urls` returns url assets, `UrlAssetType.urls` returns strings. Two fields sharing a response name in one selection set must have the same response shape, and that rule holds even for types that can never both be the concrete one, so the document is invalid and the server rejects the whole query rather than just that branch.

## Changes

- Alias the member to `urlAssets: urls`, and read it under that key.
- Assert no multi asset member shares a response name with a sibling fragment. `urls` was the only collision, and this is the check that would have caught it: the existing tests asserted the selections were present, which a syntactically fine but unmergeable query still satisfies.