### PR TITLE
Revert "fix: keep caller logging during migrations"

### DIFF
--- a/src/ostorlab/runtimes/local/models/alembic/env.py
+++ b/src/ostorlab/runtimes/local/models/alembic/env.py
@@ -17,13 +17,7 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-# `fileConfig` is process-global: it replaces the root handlers and disables the existing loggers. That is correct
-# for the `alembic` CLI, which owns a short-lived process, but destructive when migrations run embedded in a
-# long-lived one, so such callers opt out with the `configure_logger` attribute.
-if (
-    config.config_file_name is not None
-    and config.attributes.get("configure_logger", True) is True
-):
+if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 # add your model's MetaData object here

--- a/src/ostorlab/runtimes/local/models/models.py
+++ b/src/ostorlab/runtimes/local/models/models.py
@@ -97,8 +97,6 @@ class Database:
             pathlib.Path(__file__).parent.absolute() / "alembic.ini"
         )
         self._alembic_cfg = config.Config(str(self._alembic_ini_path))
-        # Migrations run in-process here, so `env.py` must not reconfigure the caller's logging.
-        self._alembic_cfg.attributes["configure_logger"] = False
 
     def __enter__(self) -> orm.Session:
         """Context manager enter method, responsible for migrating the local database and returning a session object."""

--- a/tests/runtimes/local/models/models_test.py
+++ b/tests/runtimes/local/models/models_test.py
@@ -1,9 +1,5 @@
 """Tests for Models class."""
 
-import logging
-from collections.abc import Iterator
-
-import pytest
 from pytest_mock import plugin
 
 from ostorlab.assets import android_aab, android_apk, ios_ipa, ipv4, link
@@ -857,44 +853,3 @@ def testAssetModels_whenCreateFromAssetsDefinitionWithMultiAsset_nestedAssetsCre
         assert len(links) == 1
         assert links[0].url == "https://example.com/test"
         assert links[0].method == "GET"
-
-
-@pytest.fixture
-def restored_logging_state() -> Iterator[None]:
-    """Restore the process global logging state.
-
-    `fileConfig` replaces the root handlers, lowers the root level and disables every logger that already exists,
-    so a regression would otherwise leak all of that into the rest of the session.
-    """
-    root_logger = logging.getLogger()
-    root_handlers = list(root_logger.handlers)
-    root_level = root_logger.level
-    disabled_flags = {
-        name: logging.getLogger(name).disabled
-        for name in list(logging.root.manager.loggerDict)
-    }
-    yield
-    root_logger.handlers = root_handlers
-    root_logger.setLevel(root_level)
-    for name, disabled in disabled_flags.items():
-        logging.getLogger(name).disabled = disabled
-
-
-def testDatabaseMigration_always_keepsCallerLoggingHandlers(
-    mocker, db_engine_path, restored_logging_state
-):
-    """Running migrations embedded must not let alembic's `fileConfig` reconfigure the caller's logging."""
-    mocker.patch.object(models, "ENGINE_URL", db_engine_path)
-    caller_handler = logging.NullHandler()
-    root_logger = logging.getLogger()
-    root_logger.addHandler(caller_handler)
-    root_level = root_logger.level
-    caller_logger = logging.getLogger("ostorlab.runtimes.local.runtime")
-    caller_logger.disabled = False
-
-    with models.Database() as session:
-        assert session.query(models.Scan).count() == 0
-
-    assert caller_handler in root_logger.handlers
-    assert root_logger.level == root_level
-    assert caller_logger.disabled is False


### PR DESCRIPTION
Reverts Ostorlab/oxo#1175