### PR TITLE
fix: stop logging agent arguments

### DIFF
--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -508,7 +508,7 @@ class LocalRuntime(runtime.Runtime):
         Args:
             agent: An agent definition containing all the settings of how agent should run and what arguments to pass.
         """
-        logger.info("starting agent %s with %s", agent.key, agent.args)
+        logger.info("starting agent %s", agent.key)
 
         if _has_container_image(agent) is False:
             raise AgentNotInstalled(agent.key)


### PR DESCRIPTION
Agent arguments carry credentials, and `starting agent %s with %s` logs every value in full: the reporting and scanning engine tokens, the reporting engine API key, the bus URL with its password in the userinfo, and third-party keys such as VirusTotal and NVD.

The arguments are no longer logged. The agent key alone still shows which agents a scan starts.
