### PR TITLE
fix(scanner): support apiSchemaUrl with fallback to apiSchema for UrlAssetType

### DIFF
--- a/src/ostorlab/apis/scan_update_state.py
+++ b/src/ostorlab/apis/scan_update_state.py
@@ -34,7 +34,7 @@ class ScanUpdateStateAPIRequest(request.APIRequest):
                   progress
                   asset {
                     __typename
-                    ... on UrlAssetType { urls apiSchema }
+                    ... on UrlAssetType { urls apiSchema apiSchemaUrl }
                     ... on Ipv4AssetType { host version mask }
                     ... on Ipv6AssetType { host version mask }
                     ... on IpAssetType { host version mask }
@@ -94,7 +94,7 @@ class ScanUpdateStateAPIRequest(request.APIRequest):
                         rating
                         target {
                           __typename
-                          ... on UrlAssetType { urls apiSchema }
+                          ... on UrlAssetType { urls apiSchema apiSchemaUrl }
                           ... on Ipv4AssetType { host version mask }
                           ... on Ipv6AssetType { host version mask }
                           ... on IpAssetType { host version mask }
@@ -125,7 +125,7 @@ class ScanUpdateStateAPIRequest(request.APIRequest):
                       rating 
                       target {
                         __typename
-                        ... on UrlAssetType { urls apiSchema }
+                        ... on UrlAssetType { urls apiSchema apiSchemaUrl }
                         ... on Ipv4AssetType { host version mask }
                         ... on Ipv6AssetType { host version mask }
                         ... on IpAssetType { host version mask }

--- a/src/ostorlab/scanner/callbacks.py
+++ b/src/ostorlab/scanner/callbacks.py
@@ -287,7 +287,12 @@ def _extract_assets(asset_data: dict[str, Any]) -> list[asset.Asset]:
 
         if api_schema_url is not None and str(api_schema_url).strip() != "":
             urls = kwargs.get("urls")
-            if urls is not None and len(urls) > 0 and str(urls[0]).strip() != "":
+            if (
+                urls is not None
+                and len(urls) > 0
+                and urls[0] is not None
+                and str(urls[0]).strip() != ""
+            ):
                 return [
                     api_schema_asset.ApiSchema(
                         endpoint_url=urls[0],

--- a/src/ostorlab/scanner/callbacks.py
+++ b/src/ostorlab/scanner/callbacks.py
@@ -287,16 +287,16 @@ def _extract_assets(asset_data: dict[str, Any]) -> list[asset.Asset]:
 
         if api_schema_url is not None and str(api_schema_url).strip() != "":
             urls = kwargs.get("urls")
-            endpoint_url = ""
-            if urls is not None and len(urls) > 0:
-                endpoint_url = urls[0]
-            return [
-                api_schema_asset.ApiSchema(
-                    endpoint_url=endpoint_url,
-                    content_url=api_schema_url,
-                    schema_type=None,
-                )
-            ]
+            if urls is not None and len(urls) > 0 and str(urls[0]).strip() != "":
+                return [
+                    api_schema_asset.ApiSchema(
+                        endpoint_url=urls[0],
+                        content_url=api_schema_url,
+                        schema_type=None,
+                    )
+                ]
+            logger.error("Url asset api schema holds no endpoint url.")
+            return []
         urls = kwargs.get("urls")
         if urls is not None:
             return [link_asset.Link(url=link, method="GET") for link in urls]

--- a/src/ostorlab/scanner/callbacks.py
+++ b/src/ostorlab/scanner/callbacks.py
@@ -304,8 +304,13 @@ def _extract_assets(asset_data: dict[str, Any]) -> list[asset.Asset]:
             return []
         urls = kwargs.get("urls")
         if urls is not None:
-            return [link_asset.Link(url=link, method="GET") for link in urls]
+            return [
+                link_asset.Link(url=str(link).strip(), method="GET")
+                for link in urls
+                if link is not None and str(link).strip() != ""
+            ]
         return []
+
     elif typename == "AndroidPackageNameAssetType":
         return [android_store.AndroidStore(package_name=kwargs.get("packageName", ""))]
     elif typename == "IosBundleIdAssetType":

--- a/src/ostorlab/scanner/callbacks.py
+++ b/src/ostorlab/scanner/callbacks.py
@@ -281,20 +281,26 @@ def _extract_assets(asset_data: dict[str, Any]) -> list[asset.Asset]:
             for network in kwargs.get("networks") or []
         ]
     elif typename == "UrlAssetType":
-        api_schema_url = kwargs.get("apiSchema")
+        api_schema_url = kwargs.get("apiSchemaUrl")
+        if api_schema_url is None or str(api_schema_url).strip() == "":
+            api_schema_url = kwargs.get("apiSchema")
+
         if api_schema_url is not None and str(api_schema_url).strip() != "":
-            endpoint_url = (
-                kwargs.get("urls", [""])[0] if kwargs.get("urls") is not None else ""
-            )
+            urls = kwargs.get("urls")
+            endpoint_url = ""
+            if urls is not None and len(urls) > 0:
+                endpoint_url = urls[0]
             return [
                 api_schema_asset.ApiSchema(
                     endpoint_url=endpoint_url,
                     content_url=api_schema_url,
+                    schema_type=None,
                 )
             ]
-        return [
-            link_asset.Link(url=link, method="GET") for link in kwargs.get("urls") or []
-        ]
+        urls = kwargs.get("urls")
+        if urls is not None:
+            return [link_asset.Link(url=link, method="GET") for link in urls]
+        return []
     elif typename == "AndroidPackageNameAssetType":
         return [android_store.AndroidStore(package_name=kwargs.get("packageName", ""))]
     elif typename == "IosBundleIdAssetType":

--- a/tests/apis/scan_update_state_test.py
+++ b/tests/apis/scan_update_state_test.py
@@ -34,7 +34,8 @@ def testScanUpdateStateAPIRequest_whenFullDetails_queryContainsAssetAndAgentGrou
     assert api_request.query is not None
     assert "mutation UpdateScanState" in api_request.query
     assert "$scanId: Int!" in api_request.query
-    assert "deviceId: null" not in api_request.query
+    assert "asset" in api_request.query
+    assert "agentGroup" in api_request.query
     assert (
         api_request.query.count("... on UrlAssetType { urls apiSchema apiSchemaUrl }")
         == 3

--- a/tests/apis/scan_update_state_test.py
+++ b/tests/apis/scan_update_state_test.py
@@ -37,7 +37,7 @@ def testScanUpdateStateAPIRequest_whenFullDetails_queryContainsAssetAndAgentGrou
     assert "deviceId: null" not in api_request.query
     assert "asset" in api_request.query
     assert "agentGroup" in api_request.query
-    assert "... on UrlAssetType" in api_request.query
+    assert "... on UrlAssetType { urls apiSchema apiSchemaUrl }" in api_request.query
     assert "... on AndroidApkAssetType" in api_request.query
     assert "... on IosIpaAssetType" in api_request.query
 

--- a/tests/apis/scan_update_state_test.py
+++ b/tests/apis/scan_update_state_test.py
@@ -35,9 +35,10 @@ def testScanUpdateStateAPIRequest_whenFullDetails_queryContainsAssetAndAgentGrou
     assert "mutation UpdateScanState" in api_request.query
     assert "$scanId: Int!" in api_request.query
     assert "deviceId: null" not in api_request.query
-    assert "asset" in api_request.query
-    assert "agentGroup" in api_request.query
-    assert "... on UrlAssetType { urls apiSchema apiSchemaUrl }" in api_request.query
+    assert (
+        api_request.query.count("... on UrlAssetType { urls apiSchema apiSchemaUrl }")
+        == 3
+    )
     assert "... on AndroidApkAssetType" in api_request.query
     assert "... on IosIpaAssetType" in api_request.query
 

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -1384,3 +1384,28 @@ def testExtractAssets_whenUrlAssetWithWhitespaceFirstUrl_shouldSkipAndReturnNoAs
 
     assets = runtime_mock.scan.call_args[1].get("assets")
     assert assets is None
+
+
+def testExtractAssets_whenUrlAssetWithNoneFirstUrl_shouldSkipAndReturnNoAssets(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Ensure UrlAssetType with apiSchemaUrl and None first url skips asset creation."""
+    reserved_scan = {
+        "id": 42,
+        "agentGroup": {
+            "key": "agentgroup/ostorlab/agent_group42",
+            "agents": [{"key": "agent/ostorlab/dummy"}],
+        },
+        "asset": {
+            "__typename": "UrlAssetType",
+            "urls": [None],
+            "apiSchemaUrl": "https://storage.ostorlab.co/uploads/schema.json",
+        },
+    }
+    runtime_mock = _setup_start_scan_mocks(mocker)
+    state_reporter = mocker.MagicMock()
+
+    callbacks.start_scan(reserved_scan, state_reporter)
+
+    assets = runtime_mock.scan.call_args[1].get("assets")
+    assert assets is None

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -1326,3 +1326,61 @@ def testExtractAssets_whenUrlAssetWithApiSchemaUrlAndNoUrls_shouldSkipAndReturnN
 
     assets = runtime_mock.scan.call_args[1].get("assets")
     assert assets is None
+
+
+def testExtractAssets_whenUrlAssetWithWhitespaceApiSchemaUrl_shouldFallbackToApiSchema(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Ensure UrlAssetType with whitespace-only apiSchemaUrl falls back to apiSchema."""
+    reserved_scan = {
+        "id": 42,
+        "agentGroup": {
+            "key": "agentgroup/ostorlab/agent_group42",
+            "agents": [{"key": "agent/ostorlab/dummy"}],
+        },
+        "asset": {
+            "__typename": "UrlAssetType",
+            "urls": ["https://ostorlab.co"],
+            "apiSchemaUrl": "   ",
+            "apiSchema": "https://storage.ostorlab.co/uploads/fallback_schema.json",
+        },
+    }
+    runtime_mock = _setup_start_scan_mocks(mocker)
+    state_reporter = mocker.MagicMock()
+
+    callbacks.start_scan(reserved_scan, state_reporter)
+
+    assets = runtime_mock.scan.call_args[1].get("assets")
+    assert len(assets) == 1
+    api_schema = assets[0]
+    assert isinstance(api_schema, api_schema_asset.ApiSchema) is True
+    assert api_schema.endpoint_url == "https://ostorlab.co"
+    assert (
+        api_schema.content_url
+        == "https://storage.ostorlab.co/uploads/fallback_schema.json"
+    )
+
+
+def testExtractAssets_whenUrlAssetWithWhitespaceFirstUrl_shouldSkipAndReturnNoAssets(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Ensure UrlAssetType with apiSchemaUrl and whitespace-only first url skips asset creation."""
+    reserved_scan = {
+        "id": 42,
+        "agentGroup": {
+            "key": "agentgroup/ostorlab/agent_group42",
+            "agents": [{"key": "agent/ostorlab/dummy"}],
+        },
+        "asset": {
+            "__typename": "UrlAssetType",
+            "urls": ["   "],
+            "apiSchemaUrl": "https://storage.ostorlab.co/uploads/schema.json",
+        },
+    }
+    runtime_mock = _setup_start_scan_mocks(mocker)
+    state_reporter = mocker.MagicMock()
+
+    callbacks.start_scan(reserved_scan, state_reporter)
+
+    assets = runtime_mock.scan.call_args[1].get("assets")
+    assert assets is None

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -1214,10 +1214,41 @@ def testStartScan_whenNoAssetExtracted_shouldPassNoneToRuntime(
     assert runtime_mock.scan.call_args[1].get("assets") is None
 
 
-def testExtractAssets_whenUrlAssetWithApiSchema_shouldReturnApiSchemaAsset(
+def testExtractAssets_whenUrlAssetWithApiSchemaUrl_shouldReturnApiSchemaAsset(
     mocker: plugin.MockerFixture,
 ) -> None:
-    """Ensure UrlAssetType with apiSchema returns an ApiSchema asset."""
+    """Ensure UrlAssetType with apiSchemaUrl returns an ApiSchema asset."""
+    reserved_scan = {
+        "id": 42,
+        "agentGroup": {
+            "key": "agentgroup/ostorlab/agent_group42",
+            "agents": [{"key": "agent/ostorlab/dummy"}],
+        },
+        "asset": {
+            "__typename": "UrlAssetType",
+            "urls": ["https://api.example.com/graphql"],
+            "apiSchemaUrl": "https://storage.ostorlab.co/uploads/schema.json",
+            "apiSchema": "uploads/schema.json",
+        },
+    }
+    runtime_mock = _setup_start_scan_mocks(mocker)
+    state_reporter = mocker.MagicMock()
+
+    callbacks.start_scan(reserved_scan, state_reporter)
+
+    assets = runtime_mock.scan.call_args[1].get("assets")
+    assert len(assets) == 1
+    schema_asset = assets[0]
+    assert isinstance(schema_asset, api_schema_asset.ApiSchema) is True
+    assert schema_asset.endpoint_url == "https://api.example.com/graphql"
+    assert schema_asset.content_url == "https://storage.ostorlab.co/uploads/schema.json"
+    assert schema_asset.schema_type is None
+
+
+def testExtractAssets_whenUrlAssetWithLegacyApiSchemaOnly_shouldReturnApiSchemaAsset(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Ensure UrlAssetType with only legacy apiSchema fallback returns an ApiSchema asset."""
     reserved_scan = {
         "id": 42,
         "agentGroup": {
@@ -1241,6 +1272,7 @@ def testExtractAssets_whenUrlAssetWithApiSchema_shouldReturnApiSchemaAsset(
     assert isinstance(schema_asset, api_schema_asset.ApiSchema) is True
     assert schema_asset.endpoint_url == "https://api.example.com/graphql"
     assert schema_asset.content_url == "https://storage.ostorlab.co/uploads/schema.json"
+    assert schema_asset.schema_type is None
 
 
 def testExtractAssets_whenUrlAssetWithoutApiSchema_shouldReturnLinks(

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -1301,3 +1301,28 @@ def testExtractAssets_whenUrlAssetWithoutApiSchema_shouldReturnLinks(
     assert isinstance(link, link_asset.Link) is True
     assert link.url == "https://ostorlab.co"
     assert link.method == "GET"
+
+
+def testExtractAssets_whenUrlAssetWithApiSchemaUrlAndNoUrls_shouldSkipAndReturnNoAssets(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Ensure UrlAssetType with apiSchemaUrl but empty urls skips asset creation."""
+    reserved_scan = {
+        "id": 42,
+        "agentGroup": {
+            "key": "agentgroup/ostorlab/agent_group42",
+            "agents": [{"key": "agent/ostorlab/dummy"}],
+        },
+        "asset": {
+            "__typename": "UrlAssetType",
+            "urls": [],
+            "apiSchemaUrl": "https://storage.ostorlab.co/uploads/schema.json",
+        },
+    }
+    runtime_mock = _setup_start_scan_mocks(mocker)
+    state_reporter = mocker.MagicMock()
+
+    callbacks.start_scan(reserved_scan, state_reporter)
+
+    assets = runtime_mock.scan.call_args[1].get("assets")
+    assert assets is None

--- a/tests/scanner/callbacks_test.py
+++ b/tests/scanner/callbacks_test.py
@@ -1409,3 +1409,29 @@ def testExtractAssets_whenUrlAssetWithNoneFirstUrl_shouldSkipAndReturnNoAssets(
 
     assets = runtime_mock.scan.call_args[1].get("assets")
     assert assets is None
+
+
+def testExtractAssets_whenUrlAssetWithNoneAndEmptyUrls_shouldFilterOutInvalidLinks(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Ensure UrlAssetType without apiSchema filters out None and whitespace URLs when creating Link assets."""
+    reserved_scan = {
+        "id": 42,
+        "agentGroup": {
+            "key": "agentgroup/ostorlab/agent_group42",
+            "agents": [{"key": "agent/ostorlab/dummy"}],
+        },
+        "asset": {
+            "__typename": "UrlAssetType",
+            "urls": [None, "  ", "", "https://ostorlab.co"],
+        },
+    }
+    runtime_mock = _setup_start_scan_mocks(mocker)
+    state_reporter = mocker.MagicMock()
+
+    callbacks.start_scan(reserved_scan, state_reporter)
+
+    assets = runtime_mock.scan.call_args[1].get("assets")
+    assert len(assets) == 1
+    assert isinstance(assets[0], link_asset.Link)
+    assert assets[0].url == "https://ostorlab.co"


### PR DESCRIPTION
## Summary
- Supports `apiSchemaUrl` in `ScanUpdateStateAPIRequest` GraphQL queries for `UrlAssetType`.
- Updates `_extract_assets` in `callbacks.py` to read `apiSchemaUrl` with fallback to legacy `apiSchema`.
- Instantiates `ApiSchema` with `endpoint_url`, `content_url`, and `schema_type=None` when schema is present, otherwise falls back to `Link` objects.

## Motivation & Context
- Aligns `oxo` with `ogle_scanning_engine` exposing download URLs under `apiSchemaUrl` (PR https://github.com/Ostorlab/ogle_scanning_engine/pull/730).
- Gracefully handles both new scanning engine versions emitting `apiSchemaUrl` and existing backends emitting `apiSchema`.

## Detailed Changes
- `src/ostorlab/apis/scan_update_state.py`: Add `apiSchemaUrl` to `UrlAssetType` query selections across scan asset, risk target, and risks target.
- `src/ostorlab/scanner/callbacks.py`: Parse `apiSchemaUrl` (fallback to `apiSchema`), instantiate `ApiSchema` with `schema_type=None`.
- `tests/apis/scan_update_state_test.py`: Update query assertions.
- `tests/scanner/callbacks_test.py`: Add test cases for `apiSchemaUrl`, legacy `apiSchema` fallback, and empty/missing schema scenarios.

## Test Plan & Verification
- [x] Local unit tests passed (`pytest tests/scanner/callbacks_test.py tests/apis/scan_update_state_test.py`).
- [x] Linters and formatters passed clean (`ruff check`, `ruff format`).