### PR TITLE
fix: derive scanner concurrency limit from running universes

### DIFF
--- a/src/ostorlab/cli/scanner/scanner.py
+++ b/src/ostorlab/cli/scanner/scanner.py
@@ -211,6 +211,7 @@ def scanner(
                 scanner_log_file,
                 scanner_log_level,
                 gcp_logging_credential,
+                nb_parallel_scans,
             ),
         )
         process.start()
@@ -232,6 +233,7 @@ def start_scanner(
     log_file: str | None = None,
     log_level: int = logging.INFO,
     gcp_logging_credential: str | None = None,
+    max_concurrent_scans: int = 1,
 ) -> None:
     """Run subscription to nats in event loop.
 
@@ -242,6 +244,7 @@ def start_scanner(
         log_file: Optional path to persist scanner logs.
         log_level: Logging level used for persisted scanner logs.
         gcp_logging_credential: GCP Logging JSON credentials for agent containers.
+        max_concurrent_scans: Number of universes the host may run at once.
     """
     _configure_file_logging(log_file, log_level)
     _configure_gcp_logging(gcp_logging_credential, scanner_id)
@@ -260,4 +263,5 @@ def start_scanner(
         scanner_id=scanner_id,
         state_reporter=state_reporter,
         gcp_logging_credential=gcp_logging_credential,
+        max_concurrent_scans=max_concurrent_scans,
     )

--- a/src/ostorlab/scanner/scan_handler.py
+++ b/src/ostorlab/scanner/scan_handler.py
@@ -54,7 +54,16 @@ class ScanHandler:
 
         while True:
             running_universes = self._count_running_universes()
-            if running_universes >= self._max_concurrent_scans:
+            if running_universes > self._max_concurrent_scans:
+                logger.error(
+                    "Host is running %s universe(s) over a limit of %s. Sleeping...",
+                    running_universes,
+                    self._max_concurrent_scans,
+                )
+                time.sleep(WAIT_CHECK_MESSAGES.seconds)
+                continue
+
+            if running_universes == self._max_concurrent_scans:
                 logger.debug(
                     "Host is running %s universe(s) for a limit of %s. Sleeping...",
                     running_universes,

--- a/src/ostorlab/scanner/scan_handler.py
+++ b/src/ostorlab/scanner/scan_handler.py
@@ -21,6 +21,7 @@ from ostorlab.utils import scanner_state_reporter
 logger = logging.getLogger(__name__)
 
 WAIT_CHECK_MESSAGES = datetime.timedelta(seconds=5)
+UNIVERSE_LABEL = "ostorlab.universe"
 
 
 class ScanHandler:
@@ -32,10 +33,12 @@ class ScanHandler:
         scan_resource_requirements: dict[str, scanner_conf.ScanResourceRequirements]
         | None = None,
         gcp_logging_credential: str | None = None,
+        max_concurrent_scans: int = 1,
     ):
         self._state_reporter = state_reporter
         self._scan_resource_requirements = scan_resource_requirements or {}
         self._gcp_logging_credential = gcp_logging_credential
+        self._max_concurrent_scans = max_concurrent_scans
         self._docker_client = docker.from_env()
 
     def close(self) -> None:
@@ -47,19 +50,18 @@ class ScanHandler:
         api_key: str | None = None,
     ) -> None:
         """Scan handler method responsible for fetching messages from the API and triggering the scan."""
-        scan_id = None
-
         logger.info("Starting main API polling loop.")
 
         while True:
-            if scan_id is not None and self._is_scan_running(scan_id=scan_id) is True:
-                logger.debug("Scan %s is still running. Sleeping...", scan_id)
+            running_universes = self._count_running_universes()
+            if running_universes >= self._max_concurrent_scans:
+                logger.debug(
+                    "Host is running %s universe(s) for a limit of %s. Sleeping...",
+                    running_universes,
+                    self._max_concurrent_scans,
+                )
                 time.sleep(WAIT_CHECK_MESSAGES.seconds)
                 continue
-
-            if scan_id is not None:
-                logger.debug("Scan %s has finished. Ready for next.", scan_id)
-            scan_id = None
 
             scans_list = self._fetch_available_scans(runner=runner)
             if scans_list is None or len(scans_list) == 0:
@@ -239,21 +241,33 @@ class ScanHandler:
         except Exception:
             logger.exception("FATAL: Failed to rollback scan %s", scan_id_val)
 
-    def _is_scan_running(self, scan_id: str | None) -> bool:
-        """Returns True if docker services with `ostorlab.universe` label exist."""
-        if scan_id is None:
-            return False
+    def _count_running_universes(self) -> int:
+        """Count the universes currently running on this host.
+
+        Returns:
+            The number of distinct `ostorlab.universe` label values across the
+            host services. On a Docker error, the concurrency limit is returned
+            so the caller treats the host as full.
+        """
         try:
-            scan_services: list[services.Service] = self._docker_client.services.list(
-                filters={"label": f"ostorlab.universe={scan_id!s}"}
+            universe_services: list[services.Service] = (
+                self._docker_client.services.list(
+                    filters={"label": UNIVERSE_LABEL},
+                )
             )
-            is_running = len(scan_services) > 0
-            return is_running
         except docker.errors.DockerException:
             logger.exception(
-                "Docker error checking scan %s status, assuming still running.", scan_id
+                "Docker error listing services, assuming the host is at capacity."
             )
-            return True
+            return self._max_concurrent_scans
+
+        universes = set()
+        for universe_service in universe_services:
+            labels = (universe_service.attrs.get("Spec") or {}).get("Labels") or {}
+            universe = labels.get(UNIVERSE_LABEL)
+            if universe is not None:
+                universes.add(universe)
+        return len(universes)
 
 
 def start_scan_loop(
@@ -261,6 +275,7 @@ def start_scan_loop(
     scanner_id: str,
     state_reporter: scanner_state_reporter.ScannerStateReporter,
     gcp_logging_credential: str | None = None,
+    max_concurrent_scans: int = 1,
 ) -> None:
     """Fetching the scanner configuration and starting the API polling loop.
 
@@ -269,6 +284,7 @@ def start_scan_loop(
         scanner_id: The scanner identifier.
         state_reporter: instance responsible for reporting the scanner state.
         gcp_logging_credential: GCP Logging JSON credentials for agent containers.
+        max_concurrent_scans: Number of universes the host may run at once.
     """
     logger.info("Fetching scanner configuration.")
     runner = authenticated_runner.AuthenticatedAPIRunner(api_key=api_key)
@@ -288,6 +304,7 @@ def start_scan_loop(
         state_reporter=state_reporter,
         scan_resource_requirements=config.scan_resource_requirements,
         gcp_logging_credential=gcp_logging_credential,
+        max_concurrent_scans=max_concurrent_scans,
     )
     try:
         scan_handler.handle_messages(runner=s_runner, api_key=api_key)

--- a/tests/cli/scanner/scanner_test.py
+++ b/tests/cli/scanner/scanner_test.py
@@ -136,7 +136,7 @@ def testScannerCommandInvocation_whenGcpCredentialProvided_forwardsItToProcess(
 
     assert result.exit_code == 0
     process_args = create_process_mock.call_args.kwargs["args"]
-    assert process_args[-1] == '{"project_id": "test-project"}'
+    assert process_args[5] == '{"project_id": "test-project"}'
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
@@ -245,7 +245,7 @@ def testScannerCommandInvocation_whenPersistLogsIsProvided_passesLogFileToWorker
 
     assert result.exit_code == 0
     assert create_scan_process_mock.call_count == 1
-    _, _, _, scanner_log_file, scanner_log_level, _ = (
+    _, _, _, scanner_log_file, scanner_log_level, _, _ = (
         create_scan_process_mock.call_args.kwargs["args"]
     )
     assert scanner_log_file == str(log_file)
@@ -283,7 +283,7 @@ def testScannerCommandInvocation_whenLogLevelIsProvided_passesLogLevelToWorker(
 
     assert result.exit_code == 0
     assert create_scan_process_mock.call_count == 1
-    _, _, _, scanner_log_file, scanner_log_level, _ = (
+    _, _, _, scanner_log_file, scanner_log_level, _, _ = (
         create_scan_process_mock.call_args.kwargs["args"]
     )
     assert scanner_log_file == str(log_file)

--- a/tests/scanner/scan_handler_test.py
+++ b/tests/scanner/scan_handler_test.py
@@ -1,5 +1,6 @@
 """Unit tests for scan handler module."""
 
+import docker
 import pytest
 from pytest_mock import plugin
 
@@ -29,8 +30,8 @@ def testHandleMessages_whenApiKeyProvided_forwardsApiKeyToStartScan(
     )
     mocker.patch.object(
         scan_handler.ScanHandler,
-        "_is_scan_running",
-        return_value=True,
+        "_count_running_universes",
+        side_effect=[0, 1],
     )
     mocker.patch(
         "ostorlab.scanner.scan_handler.time.sleep",
@@ -52,18 +53,49 @@ def testHandleMessages_whenApiKeyProvided_forwardsApiKeyToStartScan(
     assert trigger_mock.call_args.kwargs["api_key"] == "test_api_key"
 
 
-def testIsScanRunning_whenScanIdIsNone_returnsFalse() -> None:
-    """_is_scan_running should return False when scan_id is None."""
+def testCountRunningUniverses_whenServicesShareUniverses_countsDistinctValues(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """_count_running_universes should count distinct universes, not services."""
     state_reporter = scanner_state_reporter.ScannerStateReporter(
         scanner_id="GGBD-DJJD-DKJK-DJDD",
         hostname="test-host",
         ip="192.168.0.1",
     )
     scan_handler_instance = scan_handler.ScanHandler(state_reporter=state_reporter)
+    scan_handler_instance._docker_client = mocker.MagicMock()
+    scan_handler_instance._docker_client.services.list.return_value = [
+        mocker.MagicMock(attrs={"Spec": {"Labels": {"ostorlab.universe": "42"}}}),
+        mocker.MagicMock(attrs={"Spec": {"Labels": {"ostorlab.universe": "42"}}}),
+        mocker.MagicMock(attrs={"Spec": {"Labels": {"ostorlab.universe": "43"}}}),
+        mocker.MagicMock(attrs={"Spec": {"Labels": {}}}),
+    ]
 
-    result = scan_handler_instance._is_scan_running(scan_id=None)
+    result = scan_handler_instance._count_running_universes()
 
-    assert result is False
+    assert result == 2
+
+
+def testCountRunningUniverses_whenDockerFails_returnsLimitSoHostLooksFull(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """A Docker error must not let the host claim more scans."""
+    state_reporter = scanner_state_reporter.ScannerStateReporter(
+        scanner_id="GGBD-DJJD-DKJK-DJDD",
+        hostname="test-host",
+        ip="192.168.0.1",
+    )
+    scan_handler_instance = scan_handler.ScanHandler(
+        state_reporter=state_reporter, max_concurrent_scans=3
+    )
+    scan_handler_instance._docker_client = mocker.MagicMock()
+    scan_handler_instance._docker_client.services.list.side_effect = (
+        docker.errors.DockerException("boom")
+    )
+
+    result = scan_handler_instance._count_running_universes()
+
+    assert result == 3
 
 
 def testReserveSingleScan_whenFirstScanSucceeds_returnsScanData(
@@ -205,7 +237,10 @@ def testHandleMessages_whenGcpCredentialProvided_forwardsItToStartScan(
     docker_client = mocker.patch(
         "ostorlab.scanner.scan_handler.docker.from_env"
     ).return_value
-    docker_client.services.list.return_value = [mocker.MagicMock()]
+    docker_client.services.list.side_effect = [
+        [],
+        [mocker.MagicMock(attrs={"Spec": {"Labels": {"ostorlab.universe": "42"}}})],
+    ]
     start_scan_mock = mocker.patch(
         "ostorlab.scanner.scan_handler.callbacks.start_scan", return_value="42"
     )


### PR DESCRIPTION
## What?

The scanner daemon decides whether it may take another scan by remembering the
one scan it started, in a local variable:

```python
scan_id = None
while True:
    if scan_id is not None and self._is_scan_running(scan_id=scan_id) is True:
        sleep; continue
    ...
```

`_is_scan_running` only ever asks Docker about that one remembered id. This
replaces it with `_count_running_universes`, which counts the distinct
`ostorlab.universe` label values across the host's services, and gates the loop
on that count against a new `max_concurrent_scans` limit. The limit is the
existing `--parallel` value, plumbed through `start_scanner` and
`start_scan_loop` to `ScanHandler`.

On a Docker error the count now returns the limit, so the host is treated as
full rather than free.

## Why?

The remembered `scan_id` is process-local, so it is lost whenever the daemon
container is replaced. Universes are Swarm services and keep running across
that restart, so the new worker starts with `scan_id = None`, skips the guard
entirely, and reserves another scan within a few seconds of booting — on top of
whatever the host is already running.

On one production host this ran as a loop: an agent process grew to ~25 GB on a
31 GB machine, the kernel OOM killer fired and took the daemon container with
it, Swarm restarted the daemon, and the fresh worker claimed another scan,
which added more memory pressure. That host recorded 29 OOM kills and 12 daemon
restarts in 24 hours. Another reached 19 restarts, 24 reservations and 5
concurrent universes, with a load average of 255 on 8 cores, and stopped
accepting SSH.

Counting the host's own running universes makes the limit survive a restart,
because it is derived from the machine's state rather than from process memory.

## Changed files

- `src/ostorlab/scanner/scan_handler.py`
- `src/ostorlab/cli/scanner/scanner.py`
- `tests/scanner/scan_handler_test.py`
- `tests/cli/scanner/scanner_test.py`
