### PR TITLE
fix: Add defaults in agent creation 

### DIFF
--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -11,6 +11,7 @@ import io
 import logging
 import random
 import uuid
+from typing import Any
 
 import docker
 from docker import constants, errors
@@ -35,6 +36,17 @@ HEALTHCHECK_START_PERIOD = 2 * SECOND
 HEALTHCHECK_INTERVAL = 30 * SECOND
 MAX_SERVICE_NAME_LEN = 63
 MAX_RANDOM_NAME_LEN = 5
+# Swarm stores these fields only when they are set explicitly, and fills them in on read when
+# asked for defaults. A client that scales a service by re-fetching the spec with
+# `insertDefaults=true` then submits values the stored spec never had, which Swarm reads as a
+# changed task definition and answers by rolling the running tasks. Setting them at creation
+# keeps the stored spec complete so no such diff can appear. Values match Docker's own defaults.
+STOP_GRACE_PERIOD = 10 * SECOND
+UPDATE_MONITOR = 5 * SECOND
+UPDATE_PARALLELISM = 1
+UPDATE_FAILURE_ACTION = "pause"
+UPDATE_MAX_FAILURE_RATIO = 0
+UPDATE_ORDER = "stop-first"
 
 
 class Error(exceptions.OstorlabError):
@@ -404,6 +416,13 @@ class AgentRuntime:
                     + random_suffix
                 )
 
+        # `Resources` is built as a plain dict rather than with `docker_types_services.Resources`,
+        # which has no parameter for `MemorySwappiness`. Swarm defaults that field when it is
+        # unset, so leaving it out keeps the stored spec incomplete.
+        resources: dict[str, Any] = {"MemorySwappiness": None}
+        if mem_limit is not None:
+            resources["Limits"] = {"MemoryBytes": mem_limit}
+
         env = [
             f"UNIVERSE={self.runtime_name}",
             f"SERVICE_NAME={docker_service_name}",
@@ -439,9 +458,25 @@ class AgentRuntime:
             configs=configs,
             constraints=constraints,
             endpoint_spec=endpoint_spec,
-            resources=docker_types_services.Resources(mem_limit=mem_limit),
+            resources=resources,
             cap_add=caps,
             mode=docker_types_services.ServiceMode("replicated", replicas),
+            stop_grace_period=STOP_GRACE_PERIOD,
+            dns_config=docker_types_services.DNSConfig(),
+            update_config=docker_types_services.UpdateConfig(
+                parallelism=UPDATE_PARALLELISM,
+                failure_action=UPDATE_FAILURE_ACTION,
+                monitor=UPDATE_MONITOR,
+                max_failure_ratio=UPDATE_MAX_FAILURE_RATIO,
+                order=UPDATE_ORDER,
+            ),
+            rollback_config=docker_types_services.RollbackConfig(
+                parallelism=UPDATE_PARALLELISM,
+                failure_action=UPDATE_FAILURE_ACTION,
+                monitor=UPDATE_MONITOR,
+                max_failure_ratio=UPDATE_MAX_FAILURE_RATIO,
+                order=UPDATE_ORDER,
+            ),
         )
 
         return agent_service

--- a/tests/runtimes/local/agent_runtime_test.py
+++ b/tests/runtimes/local/agent_runtime_test.py
@@ -782,3 +782,61 @@ def testCreateScanVolumeMounts_whenVolumeIsMissing_createsSharedScanVolumeMounts
         "type": "volume",
         "read_only": False,
     }
+
+
+def testCreateAgentService_always_serviceCreatedWithSwarmDefaultsSetExplicitly(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Swarm fills unset spec fields with defaults when a client reads the spec with
+    `insertDefaults=true`. A client that then resubmits that spec to scale the service sends values
+    the stored spec never had, which Swarm reads as a changed task definition and answers by
+    rolling the running tasks. Setting the fields at creation keeps the stored spec complete."""
+    agent_def = agent_definitions.AgentDefinition(
+        name="agent_name_from_def",
+        mounts=[],
+        mem_limit=420000,
+        restart_policy="",
+        open_ports=[],
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_agent_definition_from_label",
+        return_value=agent_def,
+    )
+    mocker.patch.object(
+        ostorlab.runtimes.definitions.AgentSettings,
+        "container_image",
+        property(container_name_mock),
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.update_agent_settings",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_settings_config",
+        return_value=None,
+    )
+    mocker.patch(
+        "ostorlab.runtimes.local.agent_runtime.AgentRuntime.create_definition_config",
+        return_value=None,
+    )
+
+    docker_client = mocker.MagicMock()
+    runtime_agent = agent_runtime.AgentRuntime(
+        definitions.AgentSettings(key="agent/org/name"),
+        "42",
+        docker_client,
+        mq_service=None,
+        redis_service=None,
+        jaeger_service=None,
+        labels={},
+    )
+    runtime_agent.create_agent_service(network_name="test", extra_configs=[])
+
+    kwargs = docker_client.services.create.call_args.kwargs
+    assert kwargs["stop_grace_period"] == agent_runtime.STOP_GRACE_PERIOD
+    assert kwargs["dns_config"] is not None
+    assert "MemorySwappiness" in kwargs["resources"]
+    assert kwargs["update_config"]["Parallelism"] == agent_runtime.UPDATE_PARALLELISM
+    assert kwargs["update_config"]["Order"] == agent_runtime.UPDATE_ORDER
+    assert kwargs["rollback_config"]["Parallelism"] == agent_runtime.UPDATE_PARALLELISM
+    assert kwargs["rollback_config"]["Order"] == agent_runtime.UPDATE_ORDER


### PR DESCRIPTION
## Set Swarm service spec defaults explicitly at agent service creation

### Problem
Agent containers were being killed mid-work while their service was scaled up.

Docker stores a service spec with only the fields that were explicitly set. When a
client scales a service, docker-py re-reads the spec with `insertDefaults=true`,
which fills every unset field with Swarm's default values, and submits that whole
task template back. The resubmitted template no longer matches what Swarm has
stored, so Swarm treats it as a changed task definition and does what it does on
any definition change: it stops the running task and starts a replacement.

The result is a container killed mid-message, losing whatever it was processing.

### Fix
Set the fields Swarm would otherwise interpolate at creation time, so the stored
spec is already complete and a later read-with-defaults returns an identical
template:

- `stop_grace_period`
- `dns_config`
- `resources` (carries `MemorySwappiness`, which `docker.types.Resources` cannot express)
- `update_config`
- `rollback_config`

`RestartPolicy` and `Placement` were already set. Values match Docker's own
defaults, so runtime behaviour is unchanged — the same values are simply recorded
rather than filled in on read.

Defaults source: https://github.com/moby/swarmkit/blob/master/api/defaults/service.go

### Verification
On a service created by this branch, the stored spec and the defaults-inserted
spec are now identical:

    diff <(GET /services/{id}) <(GET /services/{id}?insertDefaults=true)   # empty

Scaling that service 1→2 leaves the original container running (`Up`, no
`\_` predecessor row in `docker service ps`). Before this change the same scale
killed it (`Exited (0)`).
