### PR TITLE
fix: escape rich markup in console output

### DIFF
--- a/src/ostorlab/cli/agent/build/build.py
+++ b/src/ostorlab/cli/agent/build/build.py
@@ -7,6 +7,7 @@ import pathlib
 import click
 import docker
 from docker import errors
+from rich import markup
 
 from ostorlab.agent.schema import loader
 from ostorlab.agent.schema import validator
@@ -40,10 +41,14 @@ def _build_image(
 ) -> None:
     """Build agent image from agent settings."""
     console.info(
-        f"Building agent [bold red]{agent_name}[/] dockerfile [bold red]{dockerfile_path}[/]"
-        f" at root [bold red]{docker_build_root}[/]."
+        f"Building agent [bold red]{markup.escape(str(agent_name))}[/]"
+        f" dockerfile [bold red]{markup.escape(str(dockerfile_path))}[/]"
+        f" at root [bold red]{markup.escape(str(docker_build_root))}[/].",
+        is_markup=True,
     )
-    with console.status(f"Building [bold red]{container_name}[/]"):
+    with console.status(
+        f"Building [bold red]{markup.escape(str(container_name))}[/]", is_markup=True
+    ):
         for log in build_progress.BuildProgress().build(
             path=docker_build_root,
             dockerfile=dockerfile_path,
@@ -59,7 +64,9 @@ def _build_image(
                 logger.debug(log)
 
     console.success(
-        f"Agent {agent_name} built, container [bold red]{container_name}[/] created."
+        f"Agent {markup.escape(str(agent_name))} built,"
+        f" container [bold red]{markup.escape(str(container_name))}[/] created.",
+        is_markup=True,
     )
 
 

--- a/src/ostorlab/cli/agent/delete/delete.py
+++ b/src/ostorlab/cli/agent/delete/delete.py
@@ -5,6 +5,7 @@ import re
 
 import click
 import docker
+from rich import markup
 
 from ostorlab.cli import console as cli_console
 from ostorlab.cli.agent.agent import agent as agent_cli
@@ -37,12 +38,20 @@ def delete(agent: str, agent_version_regex: str | None = None) -> None:
                 if agent_version_regex is None or re.match(
                     agent_version_regex, agent_container_version
                 ):
-                    console.info(f"deleting container [bold red]{t}[/]")
+                    console.info(
+                        f"deleting container [bold red]{markup.escape(t)}[/]",
+                        is_markup=True,
+                    )
                     docker_client.images.remove(t, force=True)
                     console.success(
-                        f"container image [bold red]{t}[/] deleted successfully"
+                        f"container image [bold red]{markup.escape(t)}[/]"
+                        " deleted successfully",
+                        is_markup=True,
                     )
                     deleted = True
 
     if deleted is False:
-        console.error(f"No agent matching [bold white]{agent}[/] was found")
+        console.error(
+            f"No agent matching [bold white]{markup.escape(agent)}[/] was found",
+            is_markup=True,
+        )

--- a/src/ostorlab/cli/console.py
+++ b/src/ostorlab/cli/console.py
@@ -4,7 +4,39 @@ import logging
 from typing import Any, ClassVar
 
 import rich
-from rich import box, status
+from rich import box, markup, status
+
+
+def _escape(text: Any, is_markup: bool) -> str:
+    """Escapes rich markup control characters from dynamic text.
+
+    Rich interprets square brackets as markup tags, which raises a `MarkupError` for text holding
+    unbalanced brackets, like regular expressions, URLs or asset representations.
+
+    Args:
+        text: The text to render, not necessarily a string.
+        is_markup: Whether the text is trusted to hold intentional rich markup.
+
+    Returns:
+        The text, escaped unless it is trusted markup.
+    """
+    if is_markup is True:
+        return str(text)
+    return markup.escape(str(text))
+
+
+def _escape_cell(value: Any) -> Any:
+    """Escapes a table cell, leaving rich renderables, like `Text` or `Markdown`, untouched.
+
+    Args:
+        value: The cell value, either a string or a rich renderable.
+
+    Returns:
+        The cell value, escaped if it is a string.
+    """
+    if isinstance(value, str) is False:
+        return value
+    return _escape(value, is_markup=False)
 
 
 class Console:
@@ -33,65 +65,77 @@ class Console:
         self._table = rich.table.Table
         self._logger = logger
 
-    def success(self, text: str) -> None:
+    def success(self, text: str, is_markup: bool = False) -> None:
         """Shows success message.
 
         Args:
             text: The success text to show.
+            is_markup: Whether the text holds intentional rich markup. Defaults to False.
         """
-        self._console.print(f":heavy_check_mark: {text}", style="success")
+        self._console.print(
+            f":heavy_check_mark: {_escape(text, is_markup)}", style="success"
+        )
         if self._logger is not None:
             self._logger.info(text)
 
-    def error(self, text: str) -> None:
+    def error(self, text: str, is_markup: bool = False) -> None:
         """Shows error message.
 
         Args:
             text: The error text to show.
+            is_markup: Whether the text holds intentional rich markup. Defaults to False.
         """
         self._console.print(
-            f":small_red_triangle: [bold]ERROR:[/] {text}", style="error"
+            f":small_red_triangle: [bold]ERROR:[/] {_escape(text, is_markup)}",
+            style="error",
         )
         if self._logger is not None:
             self._logger.error(text)
 
-    def warning(self, text: str) -> None:
+    def warning(self, text: str, is_markup: bool = False) -> None:
         """Shows warning message.
 
         Args:
             text: The warning text to show.
+            is_markup: Whether the text holds intentional rich markup. Defaults to False.
         """
         self._console.print(
-            f":small_orange_diamond: [bold]WARNING:[/] {text}", style="warning"
+            f":small_orange_diamond: [bold]WARNING:[/] {_escape(text, is_markup)}",
+            style="warning",
         )
         if self._logger is not None:
             self._logger.warning(text)
 
-    def info(self, text: str) -> None:
+    def info(self, text: str, is_markup: bool = False) -> None:
         """Shows general information message.
 
         Args:
             text: The general text to show.
+            is_markup: Whether the text holds intentional rich markup. Defaults to False.
         """
-        self._console.print(f":small_blue_diamond: {text}")
+        self._console.print(f":small_blue_diamond: {_escape(text, is_markup)}")
         if self._logger is not None:
             self._logger.info(text)
 
-    def status(self, text: str) -> status.Status:
+    def status(self, text: str, is_markup: bool = False) -> status.Status:
         """Shows loading text.
 
         Args:
             text: The loading text to show.
+            is_markup: Whether the text holds intentional rich markup. Defaults to False.
 
         Returns:
             The loading text.
         """
-        return self._console.status(f"[info]{text}")
+        return self._console.status(f"[info]{_escape(text, is_markup)}")
 
     def table(
         self, columns: dict[str, str], data: list[dict[str, Any]], title: str
     ) -> None:
         """Constructs a table to display a list of items.
+
+        String cells are escaped, as they hold untrusted values like asset URLs. Styled cells must
+        be passed as rich renderables, `Text` or `Markdown`, which are rendered as they are.
 
         Args:
             columns: The table columns.
@@ -99,15 +143,15 @@ class Console:
             title: The title of the table.
         """
 
-        table = self._table(title=f"\n[bold]{title}", show_lines=True)
+        table = self._table(title=f"\n[bold]{_escape(title, False)}", show_lines=True)
 
         for column in columns:
-            table.add_column(column)
+            table.add_column(_escape(column, False))
 
         for item in data:
             row_values = []
             for column in columns.values():
-                row_values.append(item[column])
+                row_values.append(_escape_cell(item[column]))
             table.add_row(*row_values)
 
         table.box = box.SQUARE_DOUBLE_HEAD

--- a/src/ostorlab/runtimes/local/log_streamer.py
+++ b/src/ostorlab/runtimes/local/log_streamer.py
@@ -49,7 +49,10 @@ class _ServiceLogStream:
             if self._stop_event.is_set():
                 break
             log_line = line[:-1].decode()
-            console.info(f"[{self._color} bold]{escape(name)}:[/] {escape(log_line)}")
+            console.info(
+                f"[{self._color} bold]{escape(name)}:[/] {escape(log_line)}",
+                is_markup=True,
+            )
 
     def stop(self) -> None:
         """Stop the log stream."""

--- a/src/ostorlab/utils/styles.py
+++ b/src/ostorlab/utils/styles.py
@@ -36,6 +36,8 @@ def _to_text(styled: str | None, fallback: str | None) -> text.Text:
 
 def style_risk(risk: str | None) -> text.Text:
     """Stylize the risk with colors."""
+    if risk is None:
+        return _to_text(None, risk)
     return _to_text(STYLE_RISK_MAP.get(risk), risk)
 
 

--- a/src/ostorlab/utils/styles.py
+++ b/src/ostorlab/utils/styles.py
@@ -1,5 +1,7 @@
 """Define methods to style components for console."""
 
+from rich import emoji, text
+
 STYLE_RISK_MAP = {
     "CRITICAL": "[bold bright_white on #263238]Critical[/]",
     "HIGH": "[bold bright_white on #F55246]High[/]",
@@ -14,36 +16,54 @@ STYLE_RISK_MAP = {
 }
 
 
-def style_risk(risk: str) -> str:
+def _to_text(styled: str | None, fallback: str | None) -> text.Text:
+    """Renders a styled markup template, falling back to the unstyled value.
+
+    The styles are returned as `Text` instead of markup strings, so that the console renders them
+    without parsing the surrounding untrusted values, like asset URLs, as markup.
+
+    Args:
+        styled: The markup template of the styled value, None if the value has no style.
+        fallback: The raw value to show unstyled, None for scans with no progress or rating.
+
+    Returns:
+        The renderable styled value, empty if there is no value to show.
+    """
+    if styled is None:
+        return text.Text(fallback if fallback is not None else "")
+    return text.Text.from_markup(emoji.Emoji.replace(styled))
+
+
+def style_risk(risk: str | None) -> text.Text:
     """Stylize the risk with colors."""
-    return STYLE_RISK_MAP.get(risk, risk)
+    return _to_text(STYLE_RISK_MAP.get(risk), risk)
 
 
-def style_progress(progress: str) -> str:
+def style_progress(progress: str | None) -> text.Text:
     """Stylize the scan progress with colors."""
     if progress == "done":
-        return "[bold green4]Done[/]"
+        return _to_text("[bold green4]Done[/]", progress)
     if progress == "error":
-        return "[bold magenta]Error[/]"
+        return _to_text("[bold magenta]Error[/]", progress)
     if progress == "not_started":
-        return "[bold bright_black]Not Started[/]"
+        return _to_text("[bold bright_black]Not Started[/]", progress)
     if progress == "stopped":
-        return "[bold bright_red]Stopped[/]"
+        return _to_text("[bold bright_red]Stopped[/]", progress)
     if progress == "in_progress":
-        return "[bold bright_cyan]Running[/]"
+        return _to_text("[bold bright_cyan]Running[/]", progress)
     else:
-        return progress
+        return _to_text(None, progress)
 
 
-def style_asset(asset: str) -> str:
+def style_asset(asset: str | None) -> text.Text:
     """Stylize the scan asset with colors and emojis."""
     if asset == "android_store":
-        return "[bold green4]:iphone: Android Store[/]"
+        return _to_text("[bold green4]:iphone: Android Store[/]", asset)
     elif asset == "ios_store":
-        return "[bold bright_white]:apple: iOS Store[/]"
+        return _to_text("[bold bright_white]:apple: iOS Store[/]", asset)
     elif asset == "android":
-        return "[bold bright_green]:iphone: Android[/]"
+        return _to_text("[bold bright_green]:iphone: Android[/]", asset)
     elif asset == "ios":
-        return "[bold white]:apple: iOS[/]"
+        return _to_text("[bold white]:apple: iOS[/]", asset)
     else:
-        return asset
+        return _to_text(None, asset)

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -1,6 +1,8 @@
 from pytest_mock import plugin
+from rich import table as rich_table
 
 from ostorlab.cli import console as cli_console
+from ostorlab.utils import styles
 
 
 def testConsoleInfo_whenLoggerSet_shouldLogMessages(
@@ -73,3 +75,83 @@ def testConsoleWarning_whenLoggerNotSet_shouldNotLogMessages(
     console.warning(warning_message)
 
     mock_logger.warning.assert_not_called()
+
+
+def testConsoleInfo_whenTextHoldsUnbalancedBrackets_shouldNotRaiseMarkupError() -> None:
+    """Asset representations may hold regexes or URLs with brackets, rich must not parse them."""
+    console = cli_console.Console()
+
+    console.info("Injecting asset: Link(url=https://example.com/[/Pattern])")
+
+
+def testConsoleErrorWarningSuccess_whenTextHoldsUnbalancedBrackets_shouldNotRaiseMarkupError() -> (
+    None
+):
+    text = "closing tag '[/Pattern]' at position 127"
+    console = cli_console.Console()
+
+    console.error(text)
+    console.warning(text)
+    console.success(text)
+    console.status(text)
+
+
+def testConsoleTable_whenDataHoldsUnbalancedBrackets_shouldNotRaiseMarkupError() -> (
+    None
+):
+    console = cli_console.Console()
+
+    console.table(
+        columns={"Target": "target"},
+        data=[{"target": "https://example.com/[/Pattern]"}],
+        title="Scans",
+    )
+
+
+def testConsoleInfo_whenIsMarkupSet_shouldRenderMarkup(
+    mocker: plugin.MockerFixture,
+) -> None:
+    console = cli_console.Console()
+    print_mock = mocker.patch.object(console._console, "print")
+
+    console.info("[bold red]agent[/]", is_markup=True)
+
+    assert print_mock.call_args[0][0] == ":small_blue_diamond: [bold red]agent[/]"
+
+
+def testConsoleTable_whenCellIsStyledAndDataHoldsBrackets_stylesCellAndEscapesData(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """The styled cells are `Text` renderables, they must survive the escaping of the string cells."""
+    console = cli_console.Console()
+    add_row_mock = mocker.patch.object(rich_table.Table, "add_row")
+
+    console.table(
+        columns={"Risk rating": "risk_rating", "Vulnerable target": "location"},
+        data=[
+            {
+                "risk_rating": styles.style_risk("HIGH"),
+                "location": "https://dummy.co/[/Pattern]",
+            }
+        ],
+        title="Scan 1: Found 1 vulnerabilities.",
+    )
+
+    risk_cell, location_cell = add_row_mock.call_args[0]
+    assert risk_cell.plain == "High"
+    assert risk_cell.spans != []
+    assert location_cell == "https://dummy.co/\\[/Pattern]"
+
+
+def testStyleRisk_whenRiskIsUnknown_returnsUnstyledText() -> None:
+    styled = styles.style_risk("NOT_A_RATING")
+
+    assert styled.plain == "NOT_A_RATING"
+    assert styled.spans == []
+
+
+def testStyleProgressAndRisk_whenValueIsNone_returnsEmptyText() -> None:
+    """Scans listed before they start have no progress nor risk rating."""
+    assert styles.style_progress(None).plain == ""
+    assert styles.style_risk(None).plain == ""
+    assert styles.style_asset(None).plain == ""

--- a/tests/cli/vulnz/list/test_list_vulnz.py
+++ b/tests/cli/vulnz/list/test_list_vulnz.py
@@ -492,14 +492,10 @@ def testOstorlabVulnzListCLI_whenListVulnz_showsVulnzOrderedByRiskRatingByDefaul
 
     assert result.exception is None
     risk_ratings = [
-        vuln.get("risk_rating") for vuln in table_mock.call_args_list[0][1].get("data")
+        vuln.get("risk_rating").plain
+        for vuln in table_mock.call_args_list[0][1].get("data")
     ]
-    assert risk_ratings == [
-        "[bold bright_white on #F55246]High[/]",
-        "[bold bright_white on #FF9800]Medium[/]",
-        "[bold bright_white on #FF9800]Medium[/]",
-        "[bold bright_white on #FDDB45]Low[/]",
-    ]
+    assert risk_ratings == ["High", "Medium", "Medium", "Low"]
 
 
 def testOstorlabVulnzListCLI_whenListVulnzOrderByID_showsVulnzOrderedByID(

--- a/tests/runtimes/local/log_streamer_test.py
+++ b/tests/runtimes/local/log_streamer_test.py
@@ -33,8 +33,8 @@ def testServiceLogStream_whenLogsAreAvailable_logsArePrintedToConsole(
     assert console_mock.info.call_count == 2
     console_mock.info.assert_has_calls(
         [
-            mock.call("[red bold]service_name:[/] log1"),
-            mock.call("[red bold]service_name:[/] log2"),
+            mock.call("[red bold]service_name:[/] log1", is_markup=True),
+            mock.call("[red bold]service_name:[/] log2", is_markup=True),
         ]
     )
 
@@ -51,7 +51,7 @@ def testServiceLogStream_whenLogLineHasRichMarkup_escapesLogLine(
     stream._stream()
 
     console_mock.info.assert_called_once_with(
-        "[red bold]service_name:[/] closing tag \\[/] without opener"
+        "[red bold]service_name:[/] closing tag \\[/] without opener", is_markup=True
     )
 
 


### PR DESCRIPTION
### Issue

Printing any text holding brackets, like a regex or a URL, raises a `MarkupError` because rich parses it as markup:

```
console.info(f"Injecting asset: {asset}")
rich.errors.MarkupError: closing tag '[/Pattern]' at position 127 doesn't match any open tag
```

On the scanner, the error escapes `_inject_assets`, the scan is rolled back to `not_started` and picked up again seconds later, looping.

### Fix

- Escape the dynamic text in `Console.info/error/warning/success/status`, with an `is_markup` flag for the few messages that hold intentional markup.
- Escape the string cells of `Console.table`, and return the styled risk ratings, progress and assets as `Text`, so the styles still render while the untrusted values stay escaped.